### PR TITLE
Update GettingStarted.tex

### DIFF
--- a/doc/GettingStarted.tex
+++ b/doc/GettingStarted.tex
@@ -25,11 +25,6 @@ There are 6 components to the Minsky interface:
 
 \htmladdimg{NewItem15.png}
 
-\item The mode buttons
-
-\htmladdimg{NewItem16.png}
-
-
 \item The Zoom buttons
 
 \htmladdimg{NewItem17.png}


### PR DESCRIPTION
Removed reference to "mode buttons" in section 2.3 as these are no longer in the program. Please note also that:
Under 2.3 – There are now more menu options at the top
Under 2.3 – There are no more “mode” buttons only simulation speed buttons
Under 2.3 – There are now three zoom buttons instead of 2, the reset zoom button has been added in recent versions
Under 2.3 – There is now a wiring/equations tab
Under 2.3 – There are many more design icons

All of these require adding new screenshots of different features - something I do not yet know how to do on Github.