### PR TITLE
Generalize setting for ECOLAB_HOME in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TK_LIB=$(dir $(shell find $(TCL_PREFIX) -name tk.tcl -path "*/tk$(TCL_VERSION)*"
 ifdef MXE
 ECOLAB_HOME=$(HOME)/usr/mxe/ecolab
 else
-ifeq ($(shell ls $(HOME)/usr/ecolab/include/ecolab.h),$(HOME)/usr/ecolab/include/ecolab.h)
+ifneq ("$(wildcard  $(HOME)/usr/ecolab/include/ecolab.h)","")
 ECOLAB_HOME=$(HOME)/usr/ecolab
 else
 ECOLAB_HOME=/usr/local/ecolab

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ TCL_LIB=$(dir $(shell find $(TCL_PREFIX) -name init.tcl -path "*/tcl$(TCL_VERSIO
 TK_LIB=$(dir $(shell find $(TCL_PREFIX) -name tk.tcl -path "*/tk$(TCL_VERSION)*" -print))
 
 # root directory for ecolab include files and libraries
+ifndef ECOLAB_HOME
 ifdef MXE
 ECOLAB_HOME=$(HOME)/usr/mxe/ecolab
 else
@@ -24,6 +25,7 @@ ifneq ("$(wildcard /usr/lib/ecolab/include/ecolab.h)","")
 ECOLAB_HOME=/usr/lib/ecolab
 else
 ECOLAB_HOME=/usr/local/ecolab
+endif
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ else
 ifneq ("$(wildcard  $(HOME)/usr/ecolab/include/ecolab.h)","")
 ECOLAB_HOME=$(HOME)/usr/ecolab
 else
+# This exists when the debian package is installed
+ifneq ("$(wildcard /usr/lib/ecolab/include/ecolab.h)","")
+ECOLAB_HOME=/usr/lib/ecolab
+else
 ECOLAB_HOME=/usr/local/ecolab
+endif
 endif
 endif
 


### PR DESCRIPTION
These commits make a few small changes to the Makefile to handle more situations when setting ECOLAB_HOME. 
- Handles case where Debian package is used
- Handles custom cases, where user specifies ECOLAB_HOME via environment variable
- Uses a simpler mechanism for testing existence of files. A bit pedantic, but it seems to be more "standard" in the sense of showing up in web search results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/66)
<!-- Reviewable:end -->
