### PR TITLE
Outer product math bug

### DIFF
--- a/doc/Reference.tex
+++ b/doc/Reference.tex
@@ -212,8 +212,13 @@ given axis, and $r_1$ and $r_2$ are the ranks of $x$ an $y$ respectively.
 
 
 \subsection{outer product $\otimes$}\label{Operation:outerProduct}
-Computes $z_{i_1,i_2,\ldots,i_{r_1},j_1,\ldots,j_{r_2}} =
-  x_{i_1,,i_2,\ldots,i_{r_1}}y_{j_1,\ldots,j_{r_2}}$.
+Computes 
+\begin{displaymath}
+$z_{i_1,i_2,\ldots,i_{r_1},j_1,\ldots,j_{r_2}} =
+x_{i_1,,i_2,\ldots,i_{r_1}}y_{j_1,\ldots,j_{r_2}}$.
+\end{displaymath}
+where $a$ is the
+given axis, and $r_1$ and $r_2$ are the ranks of $x$ an $y$ respectively.
 
 
 \section{Switch}\label{SwitchIcon}

--- a/doc/Reference.tex
+++ b/doc/Reference.tex
@@ -217,8 +217,7 @@ Computes
 $z_{i_1,i_2,\ldots,i_{r_1},j_1,\ldots,j_{r_2}} =
 x_{i_1,,i_2,\ldots,i_{r_1}}y_{j_1,\ldots,j_{r_2}}$.
 \end{displaymath}
-where $a$ is the
-given axis, and $r_1$ and $r_2$ are the ranks of $x$ an $y$ respectively.
+where $r_1$ and $r_2$ are the ranks of $x$ an $y$ respectively.
 
 
 \section{Switch}\label{SwitchIcon}


### PR DESCRIPTION
Outer product section missing explanation for variables as well as displaying maths. Note that the online version of the manual still doesn't display the maths correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/83)
<!-- Reviewable:end -->
