### PR TITLE
Removed right-arrow button under heading of rightmost Equity column

### DIFF
--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -1001,7 +1001,7 @@ namespace minsky
 		drawButton(cairo,"—",1,0,0,idx++);
       if (pos!=first && pos!=second && pos!=firstAndLast) 						// no move up button for first row containing initial conditions. For ticket 1064
         drawButton(cairo,rowCol==row? "↑": "←",0,0,0,idx++);
-      if ((pos!=first && pos!=last && pos!=firstAndLast) || rowCol == col)              // no move down button for first row containing initial conditions. For ticket 1064
+      if ((pos!=first && pos!=last && pos!=firstAndLast) || (rowCol == col && pos!=last))      // no move down button for first row containing initial conditions. For ticket 1064
         drawButton(cairo,rowCol==row? "↓": "→",0,0,0,idx++);
   }  
  


### PR DESCRIPTION
Minor code modification to remove right-arrow button on the last Equity column in Godley tables. It was not functional anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/112)
<!-- Reviewable:end -->
