### PR TITLE
definitive fix for ticket 1098

### DIFF
--- a/gui-tk/minsky.tcl
+++ b/gui-tk/minsky.tcl
@@ -686,8 +686,8 @@ proc logVarsOK {} {
 .menubar.edit add command -label "Undo" -command "undo 1" -accelerator $meta_menu-Z
 .menubar.edit add command -label "Redo" -command "undo -1" -accelerator $meta_menu-Y
 .menubar.edit add command -label "Cut" -command cut -accelerator $meta_menu-X
-.menubar.edit add command -label "Copy" -command minsky.copy -accelerator $meta_menu-C
-.menubar.edit add command -label "Paste" -command minsky.paste -accelerator $meta_menu-V
+.menubar.edit add command -label "Copy" -command "minsky.copy" -accelerator $meta_menu-C
+.menubar.edit add command -label "Paste" -command "minsky.paste" -accelerator $meta_menu-V
 .menubar.edit add command -label "Group selection" -command "minsky.createGroup" -accelerator $meta_menu-G
 .menubar.edit add command -label "Dimensions" -command dimensionsDialog
 

--- a/gui-tk/wiring.tcl
+++ b/gui-tk/wiring.tcl
@@ -497,9 +497,9 @@ proc canvasContext {x y X Y} {
     .wiring.context delete 0 end
     .wiring.context add command -label Help -command {help DesignCanvas}
     .wiring.context add command -label "Cut" -command cut
-    .wiring.context add command -label "Copy" -command minsky.copy
+    .wiring.context add command -label "Copy" -command "minsky.copy"
     .wiring.context add command -label "Save selection as" -command saveSelection
-    .wiring.context add command -label "Paste" -command minsky.paste
+    .wiring.context add command -label "Paste" -command "minsky.paste"
     .wiring.context add command -label "Bookmark here" -command "bookmarkAt $x $y $X $Y"
     .wiring.context add command -label "Group" -command "minsky.createGroup"
     .wiring.context add command -label "Lock selected Ravels" -command "minsky.canvas.lockRavelsInSelection"
@@ -629,7 +629,7 @@ proc contextMenu {x y X Y} {
                 renameVariableInstances
             }
             .wiring.context add command -label "Edit" -command "editItem"
-            .wiring.context add command -label "Copy" -command "canvas.copyItem"
+            .wiring.context add command -label "Copy" -command "minsky.copy"
             if {[$item.type]=="flow" && ![inputWired [$item.valueId]]} {
                 .wiring.context add command -label "Add integral" -command "addIntegral"
             }
@@ -650,7 +650,7 @@ proc contextMenu {x y X Y} {
                .wiring.context add command -label "Initialise Random" \
                     -command "initRandom" 
             }
-            .wiring.context add command -label "Copy" -command "canvas.copyItem"
+            .wiring.context add command -label "Copy" -command "minsky.copy"
             .wiring.context add command -label "Flip" -command "$item.flip; flip_default"
             if {[$item.type]=="integrate"} {
                .wiring.context add command -label "Toggle var binding" -command "minsky.canvas.item.toggleCoupled; canvas.requestRedraw"
@@ -695,7 +695,7 @@ proc contextMenu {x y X Y} {
         }
         "Item" {
             .wiring.context delete 0 end
-            .wiring.context add command -label "Copy" -command "canvas.copyItem"
+            .wiring.context add command -label "Copy" -command "minsky.copy"
         }
         SwitchIcon {
             .wiring.context add command -label "Add case" -command "incrCase 1" 


### PR DESCRIPTION
Certain items still remained attached to the tip of the mouse cursor upon copying and pasting, e.g., constants, parameters, variables and integral operators. This fix hopefully solves that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/116)
<!-- Reviewable:end -->
