### PR TITLE
Possible fix to 'non matching column' bug

### DIFF
--- a/model/godleyTable.h
+++ b/model/godleyTable.h
@@ -127,7 +127,7 @@ namespace minsky
 
     /// move row \a row down by \a n places (up if -ve)
     void moveRow(int row, int n);
-    void moveCol(int row, int n);
+    void moveCol(int col, int n);
 
     void dimension(unsigned rows, unsigned cols) {clear(); resize(rows,cols);}
 

--- a/model/godleyTable.h
+++ b/model/godleyTable.h
@@ -72,6 +72,13 @@ namespace minsky
         doubleEntryCompliant(other.doubleEntryCompliant),
         title(other.title)
     { }
+  
+    // Perform deep comparison of Godley tables in history to avoid spurious noAssetClass columns from arising during undo. For ticket 1118.
+    bool operator==(const GodleyTable& other) const 
+    {
+		return (data==other.data && m_assetClass==other.m_assetClass &&
+		 doubleEntryCompliant==other.doubleEntryCompliant && title==other.title);
+    }    
 
     /// class of each column (used in DE compliant mode)
     const vector<AssetClass>& _assetClass() const {return m_assetClass;}

--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -756,7 +756,7 @@ namespace minsky
   {
     x/=zoomFactor;
     int c=colX(x);
-    if (c>0)
+    if (c>0 && godleyIcon->table._assetClass(c)!=GodleyAssetClass::noAssetClass)
       {
         godleyIcon->table.cell(0,c)=name;
         minsky().importDuplicateColumn(godleyIcon->table, c);
@@ -882,7 +882,7 @@ namespace minsky
 
   void GodleyTableWindow::update()
   {
-    if (selectedCol>0 && selectedCol<int(godleyIcon->table.cols()))
+    if (selectedCol>0 && selectedCol<int(godleyIcon->table.cols()) && godleyIcon->table._assetClass(selectedCol)!=GodleyAssetClass::noAssetClass)
       {
         if (selectedRow==0)
           {

--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -825,9 +825,9 @@ namespace minsky
   void GodleyTableWindow::pushHistory()
   {
     while (history.size()>maxHistory) history.pop_front();
-    // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-    if (history.empty() || history.back().first!=godleyIcon->table.getData()) {
-      history.push_back(make_pair(godleyIcon->table.getData(), godleyIcon->table._assetClass()));
+    // Perform deep comparison of Godley tables in history to avoid spurious noAssetClass columns from arising during undo. For ticket 1118.
+    if (history.empty() || !(history.back()==godleyIcon->table)) {
+      history.push_back(godleyIcon->table);
     }
     historyPtr=history.size();
   }
@@ -839,16 +839,10 @@ namespace minsky
     historyPtr-=changes;
     if (historyPtr > 0 && historyPtr <= history.size())
       {
-        auto& d1=history[historyPtr-1].first;
-        auto& d2=history[historyPtr-1].second;
-        // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-        if (d1.empty() || d2.empty()) return; // should not happen
-        godleyIcon->table.resize(d1.size(), d1[0].size());
-        for (size_t r=0; r<godleyIcon->table.rows(); ++r)
-          for (size_t c=0; c<godleyIcon->table.cols(); ++c) {
-			godleyIcon->table.cell(r,c)=d1[r][c];
-			godleyIcon->table._assetClass(c,d2[c]);
-		}
+        auto& d=history[historyPtr-1];
+        // Perform deep comparison of Godley tables in history to avoid spurious noAssetClass columns from arising during undo. For ticket 1118.
+        if (d.getData().empty()) return; // should not happen
+		godleyIcon->table=d; 
         requestRedraw();
       }
   }

--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -466,7 +466,7 @@ namespace minsky
            {
              selectIdx=insertIdx = textIdx(x);
              auto& str=godleyIcon->table.cell(selectedRow,selectedCol);                         
-             savedText=str;
+             savedText=godleyIcon->table.cell(selectedRow, selectedCol);
            }
         else
           selectIdx=insertIdx=0;

--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -826,28 +826,28 @@ namespace minsky
   {
     while (history.size()>maxHistory) history.pop_front();
     // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-    if (history.empty() || (history.back().first!=godleyIcon->table.getData() && history.back().second!=godleyIcon->table._assetClass())) {
+    if (history.empty() || history.back().first!=godleyIcon->table.getData()) {
       history.push_back(make_pair(godleyIcon->table.getData(), godleyIcon->table._assetClass()));
     }
     historyPtr=history.size();
   }
       
   void GodleyTableWindow::undo(int changes)
-  {
+  { 
     if (historyPtr==history.size())
       pushHistory();
     historyPtr-=changes;
     if (historyPtr > 0 && historyPtr <= history.size())
       {
-        auto& d=history[historyPtr-1].first;
+        auto& d1=history[historyPtr-1].first;
+        auto& d2=history[historyPtr-1].second;
         // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-        auto& dd=history[historyPtr-1].second;
-        if (d.empty()) return; // should not happen
-        godleyIcon->table.resize(d.size(), d[0].size());
+        if (d1.empty() || d2.empty()) return; // should not happen
+        godleyIcon->table.resize(d1.size(), d1[0].size());
         for (size_t r=0; r<godleyIcon->table.rows(); ++r)
           for (size_t c=0; c<godleyIcon->table.cols(); ++c) {
-			godleyIcon->table.cell(r,c)=d[r][c];
-			godleyIcon->table._assetClass(c,dd[c]);    
+			godleyIcon->table.cell(r,c)=d1[r][c];
+			godleyIcon->table._assetClass(c,d2[c]);
 		}
         requestRedraw();
       }

--- a/model/godleyTableWindow.cc
+++ b/model/godleyTableWindow.cc
@@ -756,6 +756,7 @@ namespace minsky
   {
     x/=zoomFactor;
     int c=colX(x);
+    // Prevents a noAssetClass column to be matched with an asset or liability column. See ticket 1118.
     if (c>0 && godleyIcon->table._assetClass(c)!=GodleyAssetClass::noAssetClass)
       {
         godleyIcon->table.cell(0,c)=name;
@@ -882,6 +883,7 @@ namespace minsky
 
   void GodleyTableWindow::update()
   {
+	// Prevents a noAssetClass column to be matched with an asset or liability column. See ticket 1118.  
     if (selectedCol>0 && selectedCol<int(godleyIcon->table.cols()) && godleyIcon->table._assetClass(selectedCol)!=GodleyAssetClass::noAssetClass)
       {
         if (selectedRow==0)

--- a/model/godleyTableWindow.h
+++ b/model/godleyTableWindow.h
@@ -68,7 +68,7 @@ namespace minsky
       godleyIcon(godleyIcon), idx(idx) {}
   };
 
-  class GodleyTableWindow: public ecolab::CairoSurface, public ButtonWidgetEnums, public GodleyAssetClass
+  class GodleyTableWindow: public ecolab::CairoSurface, public ButtonWidgetEnums
   {
     
     CLASSDESC_ACCESS(GodleyTableWindow);
@@ -170,7 +170,8 @@ namespace minsky
     int rowY(double y) const;
     int motionRow=-1, motionCol=-1; ///< current cell under mouse motion
     // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-    std::deque<std::pair<GodleyTable::Data,std::vector<AssetClass>>> history;
+    //std::deque<GodleyTable::Data> history;
+    std::deque<std::pair<GodleyTable::Data,std::vector<GodleyAssetClass::AssetClass>>> history;
     ClickType clickType(double x, double y) const;
     void checkCell00(); ///<check if cell (0,0) is selected, and deselect if so
     /// handle delete or backspace. Cell assumed selected

--- a/model/godleyTableWindow.h
+++ b/model/godleyTableWindow.h
@@ -169,9 +169,8 @@ namespace minsky
     /// row at \a y in unzoomed coordinates
     int rowY(double y) const;
     int motionRow=-1, motionCol=-1; ///< current cell under mouse motion
-    // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
-    //std::deque<GodleyTable::Data> history;
-    std::deque<std::pair<GodleyTable::Data,std::vector<GodleyAssetClass::AssetClass>>> history;
+    // Perform deep comparison of Godley tables in history to avoid spurious noAssetClass columns from arising during undo. For ticket 1118.
+    std::deque<GodleyTable> history;
     ClickType clickType(double x, double y) const;
     void checkCell00(); ///<check if cell (0,0) is selected, and deselect if so
     /// handle delete or backspace. Cell assumed selected

--- a/model/godleyTableWindow.h
+++ b/model/godleyTableWindow.h
@@ -24,6 +24,7 @@
 #ifndef GODLEYTABLEWINDOW_H
 #define GODLEYTABLEWINDOW_H
 #include "godleyIcon.h"
+#include "assetClass.h"
 #include <cairoSurfaceImage.h>
 #include <memory>
 #include <vector>
@@ -67,7 +68,7 @@ namespace minsky
       godleyIcon(godleyIcon), idx(idx) {}
   };
 
-  class GodleyTableWindow: public ecolab::CairoSurface, public ButtonWidgetEnums
+  class GodleyTableWindow: public ecolab::CairoSurface, public ButtonWidgetEnums, public GodleyAssetClass
   {
     
     CLASSDESC_ACCESS(GodleyTableWindow);
@@ -168,7 +169,8 @@ namespace minsky
     /// row at \a y in unzoomed coordinates
     int rowY(double y) const;
     int motionRow=-1, motionCol=-1; ///< current cell under mouse motion
-    std::deque<GodleyTable::Data> history;
+    // Include asset class of each column in history at avoid spurious noAssetClass columns. For ticket 1118.
+    std::deque<std::pair<GodleyTable::Data,std::vector<AssetClass>>> history;
     ClickType clickType(double x, double y) const;
     void checkCell00(); ///<check if cell (0,0) is selected, and deselect if so
     /// handle delete or backspace. Cell assumed selected


### PR DESCRIPTION
The idea is to prevent balanceDuplicateColumn() in minsky.cc from checking for a match between a noAssetClass column and either a asset or liability column, which is what I think is causing the bug. But since I don't often see this particular bug and can't reproduce it at will, this fix may be a long shot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/129)
<!-- Reviewable:end -->
