### PR TITLE
Very minor fix: added zoomfactor in some parts of draw() in ravelWrap.cc

### DIFF
--- a/model/ravelWrap.cc
+++ b/model/ravelWrap.cc
@@ -314,19 +314,18 @@ namespace minsky
 
   void Ravel::draw(cairo_t* cairo) const
   {
-    double r=ravelDefaultRadius, z=zoomFactor();
+    double  z=zoomFactor(), r=ravelDefaultRadius*z;
     if (ravel) r=1.1*z*ravel_radius(ravel);
-    double s=r*z;    
-    ports[0]->moveTo(x()+1.1*s, y());
-    ports[1]->moveTo(x()-1.1*s, y());
+    ports[0]->moveTo(x()+1.1*r, y());
+    ports[1]->moveTo(x()-1.1*r, y());
     if (mouseFocus)
       {
         drawPorts(cairo);
         displayTooltip(cairo,tooltip.empty()? explanation: tooltip);
       }
     if (onResizeHandles) drawResizeHandles(cairo);
-    cairo_rectangle(cairo,-s,-s,2*s,2*s);
-    cairo_rectangle(cairo,-1.1*s,-1.1*s,2.2*s,2.2*s);
+    cairo_rectangle(cairo,-r,-r,2*r,2*r);
+    cairo_rectangle(cairo,-1.1*r,-1.1*r,2.2*r,2.2*r);
     cairo_stroke_preserve(cairo);
     if (onBorder || lockGroup)
       { // shadow the border when mouse is over it

--- a/model/ravelWrap.cc
+++ b/model/ravelWrap.cc
@@ -316,16 +316,17 @@ namespace minsky
   {
     double r=ravelDefaultRadius, z=zoomFactor();
     if (ravel) r=1.1*z*ravel_radius(ravel);
-    ports[0]->moveTo(x()+1.1*r, y());
-    ports[1]->moveTo(x()-1.1*r, y());
+    double s=r*z;    
+    ports[0]->moveTo(x()+1.1*s, y());
+    ports[1]->moveTo(x()-1.1*s, y());
     if (mouseFocus)
       {
         drawPorts(cairo);
         displayTooltip(cairo,tooltip.empty()? explanation: tooltip);
       }
     if (onResizeHandles) drawResizeHandles(cairo);
-    cairo_rectangle(cairo,-r,-r,2*r,2*r);
-    cairo_rectangle(cairo,-1.1*r,-1.1*r,2.2*r,2.2*r);
+    cairo_rectangle(cairo,-s,-s,2*s,2*s);
+    cairo_rectangle(cairo,-1.1*s,-1.1*s,2.2*s,2.2*s);
     cairo_stroke_preserve(cairo);
     if (onBorder || lockGroup)
       { // shadow the border when mouse is over it


### PR DESCRIPTION
I noticed that ravel objects were not behaving like other canvas items upon zoom in or out and added the zoomfactor to a few places in ravelWrap::draw().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/141)
<!-- Reviewable:end -->
