### PR TITLE
Ensure dimensions.size() is the same as nColAxes() upon first load of…

### DIFF
--- a/model/CSVDialog.cc
+++ b/model/CSVDialog.cc
@@ -45,6 +45,8 @@ void CSVDialog::loadFile(const string& fname)
       initialLines.emplace_back();
       getline(is, initialLines.back());
     }
+  // Ensure dimensions.size() is the same as nColAxes() upon first load of a CSV file. For ticket 974.
+  if (spec.dimensions.size()<spec.nColAxes()) spec.setDataArea(spec.nRowAxes(),spec.nColAxes());     
 }
 
 template <class Parser>

--- a/model/CSVDialog.h
+++ b/model/CSVDialog.h
@@ -35,6 +35,7 @@ namespace minsky
   {
     std::vector<std::string> initialLines; ///< initial lines of file
     double rowHeight=0;
+    CLASSDESC_ACCESS(DataSpec);    
   public:
     const unsigned numInitialLines=30;
     double xoffs=80;


### PR DESCRIPTION
… a CSV file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/148)
<!-- Reviewable:end -->
