### PR TITLE
Resize handles always visible on mousefocus for plots, groups, sheets…

### DIFF
--- a/model/group.cc
+++ b/model/group.cc
@@ -857,8 +857,9 @@ namespace minsky
     if (mouseFocus)
       {
         displayTooltip(cairo,tooltip);
+        // Resize handles always visible on mousefocus. For ticket 92.
+        drawResizeHandles(cairo);
       }
-    if (onResizeHandles) drawResizeHandles(cairo);
 
     cairo_rectangle(cairo,-0.5*width,-0.5*height,width,height);
     cairo_clip(cairo);

--- a/model/plotWidget.cc
+++ b/model/plotWidget.cc
@@ -232,7 +232,8 @@ namespace minsky
 
             cairo_rectangle(cairo,x-0.5*width,y-0.5*height,width,height);
           }
-        if (onResizeHandles) drawResizeHandles(cairo);   
+        // Resize handles always visible on mousefocus. For ticket 92.
+        drawResizeHandles(cairo);   
       }
     justDataChanged=false;
     

--- a/model/ravelWrap.cc
+++ b/model/ravelWrap.cc
@@ -329,8 +329,9 @@ namespace minsky
       {
         drawPorts(cairo);
         displayTooltip(cairo,tooltip.empty()? explanation: tooltip);
+        // Resize handles always visible on mousefocus. For ticket 92.
+        drawResizeHandles(cairo);
       }
-    if (onResizeHandles) drawResizeHandles(cairo);
     cairo_rectangle(cairo,-r,-r,2*r,2*r);
     cairo_rectangle(cairo,-1.1*r,-1.1*r,2.2*r,2.2*r);
     cairo_stroke_preserve(cairo);

--- a/model/sheet.cc
+++ b/model/sheet.cc
@@ -52,7 +52,8 @@ void Sheet::draw(cairo_t* cairo) const
     {
       drawPorts(cairo);
       displayTooltip(cairo,tooltip);
-      if (onResizeHandles) drawResizeHandles(cairo);
+      // Resize handles always visible on mousefocus. For ticket 92.
+      drawResizeHandles(cairo);
     }
 
   cairo_scale(cairo,z,z);


### PR DESCRIPTION
… and ravels. For some weird reason, Minsky can't find libravel.so after latest git pull today

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/171)
<!-- Reviewable:end -->
