### PR TITLE
Feature 94

### DIFF
--- a/model/cairoItems.h
+++ b/model/cairoItems.h
@@ -38,6 +38,7 @@ namespace minsky
   public:
     // render a variable to a given cairo context
     RenderOperation(const OperationBase& var, cairo_t* cairo=NULL);
+    
     /// render the cairo image
     void draw();
     /// half width of unrotated image
@@ -67,8 +68,10 @@ namespace minsky
     void updatePortLocs() const;
     /// half width of unrotated image
     float width() const {return w;}
+    float width(float width) {w=width; return w;}
     /// half height of unrotated image
     float height() const {return h;}
+    float height(float height) {h=height; return h;}
     /// return the boost geometry corresponding to this variable's shape
     //Polygon geom() const;
     bool inImage(float x, float y); ///< true if (x,y) within rendered image

--- a/model/variable.cc
+++ b/model/variable.cc
@@ -85,10 +85,10 @@ ClickType::Type VariableBase::clickType(float xx, float yy)
       double dx=xx-x(), dy=yy-y(); 
       if (type()!=constant && hypot(dx-r.x(hpx,hpy), dy-r.y(hpx,hpy)) < 5)
         return ClickType::onSlider; 
-      double w=0.5*rv.width()*z, h=0.5*rv.height()*z;
-      if (fabs(fabs(dx)-w) < portRadiusMult*z &&
-          fabs(fabs(dy)-h) < portRadiusMult*z &&
-          fabs(hypot(dx,dy)-hypot(w,h)) < portRadiusMult*z)
+      double w=rv.width()*z, h=rv.height()*z;
+      if (fabs(fabs(dx)-w) < portRadius*z &&
+          fabs(fabs(dy)-h) < portRadius*z &&
+          fabs(hypot(dx,dy)-hypot(w,h)) < portRadius*z)
         return ClickType::onResize;
     }
   catch (...) {}

--- a/model/variable.h
+++ b/model/variable.h
@@ -108,7 +108,6 @@ namespace minsky
     const VariableBase* variableCast() const override {return this;}
     VariableBase* variableCast() override {return this;}
 
-    
     float zoomFactor() const override;
     
     /// @{ variable displayed name
@@ -182,6 +181,7 @@ namespace minsky
         @return cairo path of icon outline
     */
     void draw(cairo_t*) const override;
+    void resize(const LassoBox& b) override;
     ClickType::Type clickType(float x, float y) override;
     
     bool inputWired() const;


### PR DESCRIPTION
For some reason the setters for width() and height() I added in the RenderVariable class do not change the values of the private members w and h of that class. I made them mutable but this still didn't make a difference. moveTo in VariableBase::resize() seems to work though...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/173)
<!-- Reviewable:end -->
