### PR TITLE
very minor fix to rectangle for docker environment in group.cc: the t…

### DIFF
--- a/model/group.cc
+++ b/model/group.cc
@@ -788,7 +788,7 @@ namespace minsky
     // the horizontal dimensions, stuffing up the bb.width()
     // calculation, and then causing the groupResize test to
     // fail. This extra clip path fixes the problem.
-    cairo_rectangle(cairo,-0.5*width,-0.5*height-topMargin, width, height+2*topMargin);
+    cairo_rectangle(cairo,-0.5*width,-0.5*height-topMargin*z, width, height+2*topMargin*z);
     cairo_clip(cairo);
 
     // draw default group icon


### PR DESCRIPTION
…op and bottom margins weren't scaling properly upon zooming. The resize arrows are still truncated by the new rectangle used to deal with the docker issue, but that is probably something that needs fixing for all items as per Steve's request that resize arrows appear "off-icon" like on Godleys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/204)
<!-- Reviewable:end -->
