### PR TITLE
Equation display coverage

### DIFF
--- a/examples/importedCSV.mky
+++ b/examples/importedCSV.mky
@@ -1,16 +1,21 @@
  <Minsky xmlns="http://minsky.sf.net/minsky">
   <schemaVersion>3</schemaVersion>
-  <minskyVersion>2.19.0-beta.19</minskyVersion>
+  <minskyVersion>2.19.0-rc.2</minskyVersion>
   <wires>
    <Wire>
-    <id>8</id>
+    <id>12</id>
     <from>0</from>
     <to>4</to>
    </Wire>
    <Wire>
-    <id>9</id>
+    <id>13</id>
     <from>2</from>
     <to>6</to>
+   </Wire>
+   <Wire>
+    <id>14</id>
+    <from>8</from>
+    <to>10</to>
    </Wire>
   </wires>
   <items>
@@ -26,7 +31,6 @@
     </ports>
     <name>dense</name>
     <slider>
-     <visible>false</visible>
      <stepRel>false</stepRel>
      <min>-1</min>
      <max>1</max>
@@ -47,7 +51,6 @@
     </ports>
     <name>sparse</name>
     <slider>
-     <visible>false</visible>
      <stepRel>false</stepRel>
      <min>-1</min>
      <max>1</max>
@@ -78,6 +81,38 @@
     <rotation>0</rotation>
     <ports>
      <int>6</int>
+    </ports>
+    <width>100</width>
+    <height>100</height>
+   </Item>
+   <Item>
+    <id>9</id>
+    <type>Variable:parameter</type>
+    <x>139</x>
+    <y>378</y>
+    <scaleFactor>1</scaleFactor>
+    <rotation>0</rotation>
+    <ports>
+     <int>8</int>
+    </ports>
+    <name>iota5</name>
+    <init>iota(5)</init>
+    <slider>
+     <stepRel>false</stepRel>
+     <min>0</min>
+     <max>0</max>
+     <step>0</step>
+    </slider>
+   </Item>
+   <Item>
+    <id>11</id>
+    <type>Sheet</type>
+    <x>362</x>
+    <y>390</y>
+    <scaleFactor>1</scaleFactor>
+    <rotation>0</rotation>
+    <ports>
+     <int>10</int>
     </ports>
     <width>100</width>
     <height>100</height>

--- a/test/00/equationDisplay.sh
+++ b/test/00/equationDisplay.sh
@@ -32,25 +32,20 @@ trap "fail" 1 2 3 15
 # use \$ in place of $ to refer to variable contents
 # exit 0 to indicate pass, and exit 1 to indicate failure
 cat >input.tcl <<EOF
-source assert.tcl
-proc afterMinskyStarted {} {
-minsky.load $here/test/testEq.mky
-.tabs select 1
-minsky.equationDisplay.requestRedraw
-assert {[lindex [.tabs tabs] [.tabs index current]]==".equations"}
-#event generate .equations.canvas  <B1-Motion> -x 100 -y 100 -warp 1
-minsky.equationDisplay.requestRedraw
-puts [minsky.equationDisplay.width]
-puts [minsky.equationDisplay.height]
-set [minsky.equationDisplay.offsx] 100
-set [minsky.equationDisplay.offsy] 100
-assert {[minsky.equationDisplay.width]>0}
-assert {[minsky.equationDisplay.height]>0}
-exit
+source $here/test/assert.tcl
+proc afterMinskyStarted {} {	
+  minsky.load $here/test/testEq.mky	
+  minsky.canvas.recentre  
+  .tabs select 1	
+  assert {[lindex [.tabs tabs] [.tabs index current]]==".equations"}
+  panCanvas 100 100
+  minsky.equationDisplay.redraw 0 0 600 800
+  assert {[minsky.equationDisplay.offsx]==100}
+  assert {[minsky.equationDisplay.offsy]==100}
+  exit
 }
 EOF
 
-cp $here/test/assert.tcl .
 $here/gui-tk/minsky input.tcl
 if test $? -ne 0; then fail; fi
 

--- a/test/00/equationDisplay.sh
+++ b/test/00/equationDisplay.sh
@@ -1,0 +1,57 @@
+#! /bin/sh
+
+here=`pwd`
+if test $? -ne 0; then exit 2; fi
+tmp=/tmp/$$
+mkdir $tmp
+if test $? -ne 0; then exit 2; fi
+cd $tmp
+if test $? -ne 0; then exit 2; fi
+
+fail()
+{
+    echo "FAILED" 1>&2
+    cd $here
+    chmod -R u+w $tmp
+    rm -rf $tmp
+    exit 1
+}
+
+pass()
+{
+    echo "PASSED" 1>&2
+    cd $here
+    chmod -R u+w $tmp
+    rm -rf $tmp
+    exit 0
+}
+
+trap "fail" 1 2 3 15
+
+# insert ecolab script code here
+# use \$ in place of $ to refer to variable contents
+# exit 0 to indicate pass, and exit 1 to indicate failure
+cat >input.tcl <<EOF
+source assert.tcl
+proc afterMinskyStarted {} {
+minsky.load $here/test/testEq.mky
+.tabs select 1
+minsky.equationDisplay.requestRedraw
+assert {[lindex [.tabs tabs] [.tabs index current]]==".equations"}
+#event generate .equations.canvas  <B1-Motion> -x 100 -y 100 -warp 1
+minsky.equationDisplay.requestRedraw
+puts [minsky.equationDisplay.width]
+puts [minsky.equationDisplay.height]
+set [minsky.equationDisplay.offsx] 100
+set [minsky.equationDisplay.offsy] 100
+assert {[minsky.equationDisplay.width]>0}
+assert {[minsky.equationDisplay.height]>0}
+exit
+}
+EOF
+
+cp $here/test/assert.tcl .
+$here/gui-tk/minsky input.tcl
+if test $? -ne 0; then fail; fi
+
+pass

--- a/test/00/parVarSheet.sh
+++ b/test/00/parVarSheet.sh
@@ -33,21 +33,26 @@ trap "fail" 1 2 3 15
 # exit 0 to indicate pass, and exit 1 to indicate failure
 cat >input.tcl <<EOF
 source $here/test/assert.tcl
-minsky.load $here/test/testEq.mky
-minsky.canvas.recentre	
 proc afterMinskyStarted {} {	
-  after 100 {
-     .tabs select 1
-     assert {[lindex [.tabs tabs] [.tabs index current]]==".equations"}
-     panCanvas 100 100 
-     minsky.equationDisplay.requestRedraw
-     after 100 {
-		 assert {[minsky.equationDisplay.width]>0}
-		 assert {[minsky.equationDisplay.height]>0}
-	 }
-  }
+  minsky.load $here/examples/importedCSV.mky	
+  
+  .tabs select 2
+  assert {[lindex [.tabs tabs] [.tabs index current]]==".parameters"}
+  panCanvas 100 100
+  minsky.parameterSheet.requestRedraw
+  assert {[minsky.parameterSheet.width]>0}
+  assert {[minsky.parameterSheet.height]>0}  
+  
+  minsky.load $here/test/testEq.mky  
+  
+  .tabs select 3
+  assert {[lindex [.tabs tabs] [.tabs index current]]==".variables"}
+  panCanvas 100 100
+  minsky.variableSheet.requestRedraw
+  assert {[minsky.variableSheet.width]>0}
+  assert {[minsky.variableSheet.height]>0} 
     
-  after 200 {tcl_exit}
+  after 100 {tcl_exit}
 }
 EOF
 

--- a/test/testMinsky.cc
+++ b/test/testMinsky.cc
@@ -17,7 +17,6 @@
   along with Minsky.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "minsky.h"
-#include "cairoItems.h"
 #include "minsky_epilogue.h"
 #include <UnitTest++/UnitTest++.h>
 #include <gsl/gsl_integration.h>

--- a/test/testMinsky.cc
+++ b/test/testMinsky.cc
@@ -189,6 +189,18 @@ SUITE(Minsky)
       CHECK_CLOSE(0.3, var["h"]->value(), 1e-4);
 
     }
+    
+  TEST_FIXTURE(TestFixture,displayEquations)
+	{
+	   	equationDisplay.offsx=0;
+	   	equationDisplay.offsy=0;
+	   	equationDisplay.requestRedraw();
+	   	CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
+	   	equationDisplay.offsx=100;
+	   	equationDisplay.offsy=100;
+	   	equationDisplay.requestRedraw();
+		CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
+	}
 
   TEST_FIXTURE(TestFixture,godleyEval)
     {

--- a/test/testMinsky.cc
+++ b/test/testMinsky.cc
@@ -189,18 +189,6 @@ SUITE(Minsky)
       CHECK_CLOSE(0.3, var["h"]->value(), 1e-4);
 
     }
-    
-//  TEST_FIXTURE(TestFixture,displayEquations)
-//	{
-//	   	//equationDisplay.offsx=0;
-//	   	//equationDisplay.offsy=0;
-//	   	//equationDisplay.requestRedraw();
-//	   	//CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
-//	   	equationDisplay.offsx=100;
-//	   	equationDisplay.offsy=100;
-//		equationDisplay.requestRedraw();
-//		
-//	}
 
   TEST_FIXTURE(TestFixture,godleyEval)
     {

--- a/test/testMinsky.cc
+++ b/test/testMinsky.cc
@@ -17,6 +17,7 @@
   along with Minsky.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "minsky.h"
+#include "cairoItems.h"
 #include "minsky_epilogue.h"
 #include <UnitTest++/UnitTest++.h>
 #include <gsl/gsl_integration.h>
@@ -190,17 +191,17 @@ SUITE(Minsky)
 
     }
     
-  TEST_FIXTURE(TestFixture,displayEquations)
-	{
-	   	equationDisplay.offsx=0;
-	   	equationDisplay.offsy=0;
-	   	equationDisplay.requestRedraw();
-	   	CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
-	   	equationDisplay.offsx=100;
-	   	equationDisplay.offsy=100;
-	   	equationDisplay.requestRedraw();
-		CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
-	}
+//  TEST_FIXTURE(TestFixture,displayEquations)
+//	{
+//	   	//equationDisplay.offsx=0;
+//	   	//equationDisplay.offsy=0;
+//	   	//equationDisplay.requestRedraw();
+//	   	//CHECK_EQUAL(flags & fullEqnDisplay_needed,0);
+//	   	equationDisplay.offsx=100;
+//	   	equationDisplay.offsy=100;
+//		equationDisplay.requestRedraw();
+//		
+//	}
 
   TEST_FIXTURE(TestFixture,godleyEval)
     {


### PR DESCRIPTION
I'm trying to touch the code in equationDisplay.cc. I manage to select the equations tabs in my new test equationDisplay.sh but I don't know if the equations are rendered on loading testEq.mky, which I think will touch most of the code in equationDisplay.cc?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/212)
<!-- Reviewable:end -->
