### PR TITLE
reverted all_of to any_of in VariableBase::visible() because it led t…

### DIFF
--- a/model/variable.cc
+++ b/model/variable.cc
@@ -418,7 +418,7 @@ bool VariableBase::visible() const
   // ensure pars and constants with invisible out wires are made invisible. for ticket 1275  
   if (type()==constant || type()==parameter)
   {
-	if (std::all_of(ports[0]->wires().begin(),ports[0]->wires().end(), [](Wire* w){return w->attachedToDefiningVar() && !w->visible();})) return false;
+	if (std::any_of(ports[0]->wires().begin(),ports[0]->wires().end(), [](Wire* w){return w->attachedToDefiningVar() && !w->visible();})) return false;
 	else return true;
   }  
   // ensure flow vars with out wires remain visible. for ticket 1275

--- a/model/variable.cc
+++ b/model/variable.cc
@@ -415,8 +415,8 @@ bool VariableBase::visible() const
   auto g=group.lock();
   //toplevel i/o items always visible
   if ((!g || !g->group.lock()) && g==controller.lock()) return true;
-  // ensure pars and constants with invisible out wires are made invisible. for ticket 1275  
-  if (type()==constant || type()==parameter)
+  // ensure pars, constants and flows with invisible out wires are made invisible. for ticket 1275  
+  if ((type()==constant || type()==parameter) && !ports[0]->wires().empty())
   {
 	if (std::any_of(ports[0]->wires().begin(),ports[0]->wires().end(), [](Wire* w){return w->attachedToDefiningVar() && !w->visible();})) return false;
 	else return true;


### PR DESCRIPTION
…o invisible unwired pars and consts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/252)
<!-- Reviewable:end -->
