### PR TITLE
Bugfix 1243

### DIFF
--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -664,53 +664,55 @@ namespace minsky
     if (auto g=dynamic_cast<Group*>(item.get()))
       {		  
         if (auto p=g->group.lock())
-		  if (!g->empty()) // minskly crashes if group empty and ungrouped subsequently. for ticket 1243
-		    {  	    				 
-               // stash values of parameters in copied group, as they are reset for some unknown reason later on. for tickets 1243/1258
-               map<string,string> existingParms; 
-               for (auto& i: g->items) {
-                   auto v=i->variableCast(); 
-                   if (v && v->type()==VariableType::parameter) 
-	           		existingParms.emplace(v->valueId(),v->init());
-	           }
+          {
+            if (!g->empty()) // minskly crashes if group empty and ungrouped subsequently. for ticket 1243
+              {  	    				 
+                // stash values of parameters in copied group, as they are reset for some unknown reason later on. for tickets 1243/1258
+                map<string,string> existingParms; 
+                for (auto& i: g->items) {
+                  auto v=i->variableCast(); 
+                  if (v && v->type()==VariableType::parameter) 
+                    existingParms.emplace(v->valueId(),v->init());
+                }
 		       
-               auto copyOfItems=g->items;
-               auto copyOfGroups=g->groups;				  
+                auto copyOfItems=g->items;
+                auto copyOfGroups=g->groups;				  
                
-               p->moveContents(*g);
-               deleteItem();
+                p->moveContents(*g);
+                deleteItem();
                
-	           selection.clear();  // ensure no previous selection because ungrouped items will be left in selection afterwards.             
+                selection.clear();  // ensure no previous selection because ungrouped items will be left in selection afterwards.             
                
-               // leave newly ungrouped items in selection
-               for (auto& i: copyOfItems) {
+                // leave newly ungrouped items in selection
+                for (auto& i: copyOfItems) {
                   selection.toggleItemMembership(i);
                   // ensure that initial values of pasted parameters are correct. for ticket 1243/1258
                   if (auto v=i->variableCast())
-	           	 if (v->type()==VariableType::parameter && !existingParms.empty()) 
-	           	 {
-	           	   auto it=existingParms.find(v->valueId());
-	           	   if (it!=existingParms.end()) v->init(it->second);
-	                }
-	           }
+                    if (v->type()==VariableType::parameter && !existingParms.empty()) 
+                      {
+                        auto it=existingParms.find(v->valueId());
+                        if (it!=existingParms.end()) v->init(it->second);
+                      }
+                }
 	           
-	           selection.autoLayout();
+                selection.autoLayout();
 	           
-	           if (!existingParms.empty()) existingParms.clear();
+                if (!existingParms.empty()) existingParms.clear();
 	           
-               // Attach mouse focus only to first visible item in selection. For ticket 1098.      
-               for (auto& i: selection.items)
-                 if (i->visible())
-                   {
-                     setItemFocus(i);
-                     break;
-                   }
+                // Attach mouse focus only to first visible item in selection. For ticket 1098.      
+                for (auto& i: selection.items)
+                  if (i->visible())
+                    {
+                      setItemFocus(i);
+                      break;
+                    }
                                    
-               if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);           
-		  } else {
-		  	p->moveContents(*g);
-            deleteItem();
-		  }          
+                if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);           
+              } else {
+              p->moveContents(*g);
+              deleteItem();
+            }
+          }       
         
         // else item is toplevel which can't be ungrouped
       }

--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -662,12 +662,52 @@ namespace minsky
   void Canvas::ungroupItem()
   {
     if (auto g=dynamic_cast<Group*>(item.get()))
-      {
+      {	    		  
         if (auto p=g->group.lock())
           {
+        // stash values of parameters in copied group, as they are reset for some unknown reason later on.
+            map<string,string> existingParms; 
+            for (auto& i: g->items) {
+                auto v=i->variableCast(); 
+                if (v && v->type()==VariableType::parameter) 
+	        		existingParms.emplace(v->valueId(),v->init());
+	        }
+		    
+            auto copyOfItems=g->items;
+            auto copyOfGroups=g->groups;				  
+            
             p->moveContents(*g);
             deleteItem();
-          }
+            
+            // leave newly ungrouped items in selection
+            for (auto& i: copyOfItems) {
+               selection.toggleItemMembership(i);
+               // ensure that initial values of pasted parameters are correct. for ticket 1258
+               if (auto v=i->variableCast())
+	        	 if (v->type()==VariableType::parameter && !existingParms.empty()) 
+	        	 {
+	        	   auto it=existingParms.find(v->valueId());
+	        	   if (it!=existingParms.end()) v->init(it->second);
+	           }
+	        }
+	        
+	        selection.autoLayout();
+	        
+	        if (!existingParms.empty()) existingParms.clear();
+	        
+	        //selection.clear();
+	        
+            // Attach mouse focus only to first visible item in selection. For ticket 1098.      
+            for (auto& i: selection.items)
+              if (i->visible())
+                {
+                  setItemFocus(i);
+                  break;
+                }
+                                
+            if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);               
+          }           
+        
         // else item is toplevel which can't be ungrouped
       }
   }

--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -664,7 +664,7 @@ namespace minsky
     if (auto g=dynamic_cast<Group*>(item.get()))
       {		  
         if (auto p=g->group.lock())
-		  if (!g->empty())   // minskly crashes if group empty and ungrouped subsequently. for ticket 1243
+		  if (!g->empty()) // minskly crashes if group empty and ungrouped subsequently. for ticket 1243
 		    {  	    				 
                // stash values of parameters in copied group, as they are reset for some unknown reason later on. for tickets 1243/1258
                map<string,string> existingParms; 
@@ -679,6 +679,8 @@ namespace minsky
                
                p->moveContents(*g);
                deleteItem();
+               
+	           selection.clear();  // ensure no previous selection because ungrouped items will be left in selection afterwards.             
                
                // leave newly ungrouped items in selection
                for (auto& i: copyOfItems) {
@@ -696,8 +698,6 @@ namespace minsky
 	           
 	           if (!existingParms.empty()) existingParms.clear();
 	           
-	           //selection.clear();
-	           
                // Attach mouse focus only to first visible item in selection. For ticket 1098.      
                for (auto& i: selection.items)
                  if (i->visible())
@@ -706,7 +706,7 @@ namespace minsky
                      break;
                    }
                                    
-               if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);               
+               if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);           
 		  } else {
 		  	p->moveContents(*g);
             deleteItem();

--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -662,51 +662,55 @@ namespace minsky
   void Canvas::ungroupItem()
   {
     if (auto g=dynamic_cast<Group*>(item.get()))
-      {	    		  
+      {		  
         if (auto p=g->group.lock())
-          {
-        // stash values of parameters in copied group, as they are reset for some unknown reason later on.
-            map<string,string> existingParms; 
-            for (auto& i: g->items) {
-                auto v=i->variableCast(); 
-                if (v && v->type()==VariableType::parameter) 
-	        		existingParms.emplace(v->valueId(),v->init());
-	        }
-		    
-            auto copyOfItems=g->items;
-            auto copyOfGroups=g->groups;				  
-            
-            p->moveContents(*g);
-            deleteItem();
-            
-            // leave newly ungrouped items in selection
-            for (auto& i: copyOfItems) {
-               selection.toggleItemMembership(i);
-               // ensure that initial values of pasted parameters are correct. for ticket 1258
-               if (auto v=i->variableCast())
-	        	 if (v->type()==VariableType::parameter && !existingParms.empty()) 
-	        	 {
-	        	   auto it=existingParms.find(v->valueId());
-	        	   if (it!=existingParms.end()) v->init(it->second);
+		  if (!g->empty())   // minskly crashes if group empty and ungrouped subsequently. for ticket 1243
+		    {  	    				 
+               // stash values of parameters in copied group, as they are reset for some unknown reason later on. for tickets 1243/1258
+               map<string,string> existingParms; 
+               for (auto& i: g->items) {
+                   auto v=i->variableCast(); 
+                   if (v && v->type()==VariableType::parameter) 
+	           		existingParms.emplace(v->valueId(),v->init());
 	           }
-	        }
-	        
-	        selection.autoLayout();
-	        
-	        if (!existingParms.empty()) existingParms.clear();
-	        
-	        //selection.clear();
-	        
-            // Attach mouse focus only to first visible item in selection. For ticket 1098.      
-            for (auto& i: selection.items)
-              if (i->visible())
-                {
-                  setItemFocus(i);
-                  break;
-                }
-                                
-            if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);               
-          }           
+		       
+               auto copyOfItems=g->items;
+               auto copyOfGroups=g->groups;				  
+               
+               p->moveContents(*g);
+               deleteItem();
+               
+               // leave newly ungrouped items in selection
+               for (auto& i: copyOfItems) {
+                  selection.toggleItemMembership(i);
+                  // ensure that initial values of pasted parameters are correct. for ticket 1243/1258
+                  if (auto v=i->variableCast())
+	           	 if (v->type()==VariableType::parameter && !existingParms.empty()) 
+	           	 {
+	           	   auto it=existingParms.find(v->valueId());
+	           	   if (it!=existingParms.end()) v->init(it->second);
+	                }
+	           }
+	           
+	           selection.autoLayout();
+	           
+	           if (!existingParms.empty()) existingParms.clear();
+	           
+	           //selection.clear();
+	           
+               // Attach mouse focus only to first visible item in selection. For ticket 1098.      
+               for (auto& i: selection.items)
+                 if (i->visible())
+                   {
+                     setItemFocus(i);
+                     break;
+                   }
+                                   
+               if (!copyOfGroups.empty()) setItemFocus(copyOfGroups[0]);               
+		  } else {
+		  	p->moveContents(*g);
+            deleteItem();
+		  }          
         
         // else item is toplevel which can't be ungrouped
       }

--- a/test/testModel.cc
+++ b/test/testModel.cc
@@ -813,6 +813,7 @@ SUITE(Canvas)
         unsigned originalNumGroups=model->numGroups();
         canvas.item=group0;
         canvas.ungroupItem();
+        canvas.mouseDown(group0->x(),group0->y());
         CHECK_EQUAL(originalNumItems, model->numItems());
         CHECK_EQUAL(originalNumGroups-1, model->numGroups());
       }

--- a/test/testModel.cc
+++ b/test/testModel.cc
@@ -811,7 +811,7 @@ SUITE(Canvas)
       {
         unsigned originalNumItems=model->numItems();
         unsigned originalNumGroups=model->numGroups();
-        canvas.item=group0;    
+        canvas.item=group0;
         canvas.ungroupItem();
         CHECK_EQUAL(originalNumItems, model->numItems());
         CHECK_EQUAL(originalNumGroups-1, model->numGroups());

--- a/test/testModel.cc
+++ b/test/testModel.cc
@@ -811,9 +811,8 @@ SUITE(Canvas)
       {
         unsigned originalNumItems=model->numItems();
         unsigned originalNumGroups=model->numGroups();
-        canvas.item=group0;
+        canvas.item=group0;    
         canvas.ungroupItem();
-        canvas.mouseDown(group0->x(),group0->y());
         CHECK_EQUAL(originalNumItems, model->numItems());
         CHECK_EQUAL(originalNumGroups-1, model->numGroups());
       }


### PR DESCRIPTION
Canvas::unGroupItem() does a bit more heavy-lifting now by using auto-layout on the newly ungrouped items. This necessarily requires leaving them in selection to avoid them ending up under/over other items of the canvas. Some of the code from Minsky::paste() has also been repurposed to prevent parameter values from being reset to zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/272)
<!-- Reviewable:end -->
