### PR TITLE
Bugfix 1291

### DIFF
--- a/gui-tk/wiring.tcl
+++ b/gui-tk/wiring.tcl
@@ -407,16 +407,13 @@ proc textOK {} {
     destroy .textInput
     canvas.moveOffsX 0
     canvas.moveOffsY 0
-	if [regexp "^\\\[a-zA-Z\]+$" $textBuffer] {  # ensure that names escaped with \ can be used as ops or pars and vars as the case may be. for ticket 1291
+	if {[lsearch [availableOperations] $textBuffer]>-1} {
 		  set subTextBuffer [string range $textBuffer 1 end]
-		  puts $subTextBuffer
-		  if {[lsearch [availableOperations] $subTextBuffer]>-1} {
+		  if {[lsearch [availableOperations] $subTextBuffer]>-1} { # ensure that names escaped with \ can be used as ops or pars and vars as the case may be. for ticket 1291
 			  addOperationKey $subTextBuffer
 		  } else {
-			  minsky.addVariable $subTextBuffer flow
-		  }
-	} elseif {[lsearch [availableOperations] $textBuffer]>-1} {
-	      addOperationKey $textBuffer
+			  addOperationKey $textBuffer
+		  }  
 	} elseif {[llength $textBuffer]==1 && [string match "-" $textBuffer]} { # minus sign only creates subtract op. for ticket 145
 		addOperationKey subtract		
     } elseif [string match "\[%#\]*" $textBuffer] {

--- a/gui-tk/wiring.tcl
+++ b/gui-tk/wiring.tcl
@@ -407,10 +407,16 @@ proc textOK {} {
     destroy .textInput
     canvas.moveOffsX 0
     canvas.moveOffsY 0
-    if [regexp R"\\+" $textBuffer] {  # ensure that special characters escaped with \ can be used as pars and vars. for ticket 1291
-        if {[lsearch [availableOperations] $textBuffer]>-1} {
-		  addOperationKey $textBuffer
-	  }
+	if [regexp "^\\\[a-zA-Z\]+$" $textBuffer] {  # ensure that names escaped with \ can be used as ops or pars and vars as the case may be. for ticket 1291
+		  set subTextBuffer [string range $textBuffer 1 end]
+		  puts $subTextBuffer
+		  if {[lsearch [availableOperations] $subTextBuffer]>-1} {
+			  addOperationKey $subTextBuffer
+		  } else {
+			  minsky.addVariable $subTextBuffer flow
+		  }
+	} elseif {[lsearch [availableOperations] $textBuffer]>-1} {
+	      addOperationKey $textBuffer
 	} elseif {[llength $textBuffer]==1 && [string match "-" $textBuffer]} { # minus sign only creates subtract op. for ticket 145
 		addOperationKey subtract		
     } elseif [string match "\[%#\]*" $textBuffer] {

--- a/gui-tk/wiring.tcl
+++ b/gui-tk/wiring.tcl
@@ -407,8 +407,10 @@ proc textOK {} {
     destroy .textInput
     canvas.moveOffsX 0
     canvas.moveOffsY 0
-    if {[lsearch [availableOperations] $textBuffer]>-1} {
-		addOperationKey $textBuffer
+    if [regexp R"\\+" $textBuffer] {  # ensure that special characters escaped with \ can be used as pars and vars. for ticket 1291
+        if {[lsearch [availableOperations] $textBuffer]>-1} {
+		  addOperationKey $textBuffer
+	  }
 	} elseif {[llength $textBuffer]==1 && [string match "-" $textBuffer]} { # minus sign only creates subtract op. for ticket 145
 		addOperationKey subtract		
     } elseif [string match "\[%#\]*" $textBuffer] {


### PR DESCRIPTION
This is supposed to pick up names such as \Gamma, \sin, etc. and then check the substring to convert it into an op or flow var as the case may be. I checked the regex at regex101.com and it works as it is supposed to, but I don't understand why it is not working in tcl/tk. At regex101: https://regex101.com/r/FZgMbO/1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/281)
<!-- Reviewable:end -->
