### PR TITLE
Creating child window for rendering

### DIFF
--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -77,12 +77,38 @@ namespace minsky
     int err=XGetWindowAttributes(display, window, &wAttr);
     if (err>1)
       throw runtime_error("Invalid window: "+to_string(window));
-    cairo::SurfacePtr r(new cairo::Surface(cairo_xlib_surface_create(display,window,wAttr.visual,wAttr.width,wAttr.height),wAttr.width,wAttr.height));
+
+
+    int padding = 10;
+    int yOffset = 150;
+    int childWindowWidth = wAttr.width - 2*padding;
+    int childWindowHeight = wAttr.height - yOffset - padding;
+
+    unsigned long childWindow = XCreateSimpleWindow(display, window, padding, yOffset, childWindowWidth, childWindowHeight, 0, 0, 0);
+    XMapWindow(display, childWindow);
+
+    cout << "Child Window ID ::"<< childWindow << endl;
+    //XSelectInput(d, da, ButtonPressMask | KeyPressMask);
+    cout << "wAttr(x, y)::" << wAttr.x << "," << wAttr.y << endl;
+
+    cairo::SurfacePtr r(new cairo::Surface(cairo_xlib_surface_create(display, childWindow,wAttr.visual, childWindowWidth, childWindowHeight), childWindowWidth, childWindowHeight));
     cairo_surface_set_device_offset(r->surface(), -wAttr.x, -wAttr.y);
+
+    cairo_move_to(r->cairo(), 0, 0);
+    cairo_set_source_rgb(r->cairo(), 1, 1, 1);
+    cairo_paint(r->cairo());
     return r;
   }
 #endif
-  
+
+
+  void RenderNativeWindow::initializeNativeWindow(unsigned long window) {
+
+  }
+
+  void RenderNativeWindow::renderFrame() {
+
+  }
 
   void RenderNativeWindow::renderToNativeWindow(unsigned long window)
   {

--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -30,29 +30,6 @@ Please especially review the lifecycle (constructors, desctructors and copy cons
 #include "windowInformation.h"
 #include "minsky_epilogue.h"
 
-#if defined(CAIRO_HAS_XLIB_SURFACE) && !defined(MAC_OSX_TK)
-#include <cairo/cairo-xlib.h>
-#include <X11/Xlib.h>
-#endif
-
-#if defined(CAIRO_HAS_WIN32_SURFACE) && !defined(__CYGWIN__)
-#define USE_WIN32_SURFACE
-#endif
-
-#ifdef _WIN32
-#undef Realloc
-#include <windows.h>
-#include <wingdi.h>
-#ifdef USE_WIN32_SURFACE
-#include <cairo/cairo-win32.h>
-#endif
-#endif
-
-#if defined(MAC_OSX_TK)
-#include <Carbon/Carbon.h>
-#include <cairo/cairo-quartz.h>
-#include "getContext.h"
-#endif
 
 #include <stdexcept>
 #include <string>
@@ -62,29 +39,14 @@ using namespace ecolab;
 
 namespace minsky
 {
-#ifdef USE_WIN32_SURFACE
-  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation &winInfo)
-  { /* TODO */
-  }
-#elif defined(MAC_OSX_TK)
-  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation &winInfo)
-  { /* TODO */
-  }
-#else
-  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation &wi)
-  {
-    cairo::SurfacePtr childSurface(new cairo::Surface(cairo_xlib_surface_create(wi.getDisplay(), wi.getChildWindowId(), wi.wAttr.visual, wi.childWidth, wi.childHeight), wi.childWidth, wi.childHeight));
-    cairo_surface_set_device_offset(childSurface->surface(), -wi.wAttr.x, -wi.wAttr.y);
-    return childSurface;
-  }
-#endif
-
   void RenderNativeWindow::renderFrame(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight)
   {
     if (!winInfoPtr)
      winInfoPtr=std::make_shared<WindowInformation>(parentWindowId, offsetLeft, offsetTop, childWidth, childHeight);
 
-    auto tmp = createNativeWindowSurface(*winInfoPtr);
+    auto tmp = winInfoPtr->getSurface();
+    
+    //auto tmp = createNativeWindowSurface(*winInfoPtr);
 
     //TODO:: Review if this paint (below 3 lines) is really needed with each frame
     cairo_move_to(tmp->cairo(), 0, 0);

--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -181,4 +181,9 @@ namespace minsky
     offsetTop = max(180, offsetTop);
     this->winInfo->initialize(parentWindowId, offsetLeft, offsetTop, childWidth, childHeight);
   }
+
+
+  void RenderNativeWindow::resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight) {
+    // TODO:: To be implemented... need to recreate child window
+  }
 } // namespace minsky

--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -54,67 +54,110 @@ using namespace ecolab;
 namespace minsky
 {
 #ifdef USE_WIN32_SURFACE
-  inline cairo::SurfacePtr nativeWindowSurface(unsigned long window)
-  {/* TODO */}
+  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation *winInfo)
+  { /* TODO */
+  }
 #elif defined(MAC_OSX_TK)
-  inline cairo::SurfacePtr nativeWindowSurface(unsigned long window)
-  {/* TODO */}
+  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation *winInfo)
+  { /* TODO */
+  }
 #else
 
-  int throwOnXError(Display*, XErrorEvent* ev)
+  int throwOnXError(Display *, XErrorEvent *ev)
   {
     char errorMessage[256];
     XGetErrorText(ev->display, ev->error_code, errorMessage, sizeof(errorMessage));
     throw runtime_error(errorMessage);
   }
-  
-  inline cairo::SurfacePtr nativeWindowSurface(unsigned long window)
+
+  inline cairo::SurfacePtr createNativeWindowSurface(WindowInformation *wi)
   {
-    // ensure errors are thrown, rather than exit() being called
-    static bool errorHandlingSet=(XSetErrorHandler(throwOnXError), true);
-    XWindowAttributes wAttr;
-    auto display=XOpenDisplay(nullptr);
-    int err=XGetWindowAttributes(display, window, &wAttr);
-    if (err>1)
-      throw runtime_error("Invalid window: "+to_string(window));
-
-
-    int padding = 10;
-    int yOffset = 150;
-    int childWindowWidth = wAttr.width - 2*padding;
-    int childWindowHeight = wAttr.height - yOffset - padding;
-
-    unsigned long childWindow = XCreateSimpleWindow(display, window, padding, yOffset, childWindowWidth, childWindowHeight, 0, 0, 0);
-    XMapWindow(display, childWindow);
-
-    cout << "Child Window ID ::"<< childWindow << endl;
-    //XSelectInput(d, da, ButtonPressMask | KeyPressMask);
-    cout << "wAttr(x, y)::" << wAttr.x << "," << wAttr.y << endl;
-
-    cairo::SurfacePtr r(new cairo::Surface(cairo_xlib_surface_create(display, childWindow,wAttr.visual, childWindowWidth, childWindowHeight), childWindowWidth, childWindowHeight));
-    cairo_surface_set_device_offset(r->surface(), -wAttr.x, -wAttr.y);
-
-    cairo_move_to(r->cairo(), 0, 0);
-    cairo_set_source_rgb(r->cairo(), 1, 1, 1);
-    cairo_paint(r->cairo());
-    return r;
+    cairo::SurfacePtr childSurface(new cairo::Surface(cairo_xlib_surface_create(wi->display, wi->childWindowId, wi->wAttr.visual, wi->childWidth, wi->childHeight), wi->childWidth, wi->childHeight));
+    cairo_surface_set_device_offset(childSurface->surface(), -wi->wAttr.x, -wi->wAttr.y);
+    return childSurface;
   }
 #endif
 
-
-  void RenderNativeWindow::initializeNativeWindow(unsigned long window) {
-
-  }
-
-  void RenderNativeWindow::renderFrame() {
-
-  }
-
-  void RenderNativeWindow::renderToNativeWindow(unsigned long window)
+  WindowInformation::WindowInformation()
   {
-    auto tmp=nativeWindowSurface(window);
+  }
+  WindowInformation::~WindowInformation() {
+    cout << "Delete called for window information" << endl;
+  }
+
+  void WindowInformation::initialize(unsigned long parentWin, int left, int top)
+  {
+    parentWindowId = parentWin;
+    offsetLeft = left;
+    offsetTop = top;
+
+    static bool errorHandlingSet = (XSetErrorHandler(throwOnXError), true);
+    display = XOpenDisplay(nullptr);
+    int err = XGetWindowAttributes(display, parentWin, &wAttr);
+    if (err > 1)
+      throw runtime_error("Invalid window: " + to_string(parentWin));
+
+    int padding = offsetLeft;
+    int yOffset = offsetTop;
+
+    childWidth = wAttr.width - 2 * padding;
+    childHeight = wAttr.height - yOffset - padding;
+
+    childWindowId = XCreateSimpleWindow(display, parentWin, offsetTop, offsetLeft, childWidth, childHeight, 0, 0, 0);
+    XMapWindow(display, childWindowId);
+  }
+
+  void WindowInformation::copy(WindowInformation *winInfo)
+  {
+    this->parentWindowId = winInfo->parentWindowId;
+    this->childWindowId = winInfo->childWindowId;
+    this->offsetLeft = winInfo->offsetLeft;
+    this->offsetTop = winInfo->offsetTop;
+    this->display = winInfo->display;
+    this->wAttr = winInfo->wAttr;
+    // this->childSurface = winInfo->childSurface;// TODO:: Later, try reusing the surface also in winInfo
+  }
+
+  RenderNativeWindow::RenderNativeWindow()
+  {
+    winInfo = new WindowInformation(); // TODO:: Try to reuse the WindowInformation object instead of creating a new one.... perhaps it should be a static data member?
+  }
+
+  RenderNativeWindow::~RenderNativeWindow()
+  {
+    delete winInfo;
+  }
+
+  RenderNativeWindow &RenderNativeWindow::operator=(const RenderNativeWindow &a)
+  {
+    cout << "Calling assignment on renderNativeWindow" << endl;
+    a.winInfo->copy(this->winInfo);
+    return *this;
+  }
+
+  RenderNativeWindow::RenderNativeWindow(const RenderNativeWindow &a)
+  {
+    cout << "Copy constructor for RenderNativeWindow called... TODO:: implement this" << endl;
+    //a.winInfo->copy(this->winInfo); // reverse?
+  };
+
+  void RenderNativeWindow::renderFrame()
+  {
+    auto tmp = createNativeWindowSurface(winInfo);
+    
+    //TODO:: Review if this paint (below 3 lines) is really needed with each frame
+    cairo_move_to(tmp->cairo(), 0, 0);
+    cairo_set_source_rgb(tmp->cairo(), 1, 1, 1);
+    cairo_paint(tmp->cairo());
+
     tmp.swap(surface);
-    redraw(0,0,surface->width(),surface->height());
+    redraw(0, 0, surface->width(), surface->height());
     tmp.swap(surface);
   }
-}
+
+  void RenderNativeWindow::initializeNativeWindow(unsigned long parentWindowId)
+  {
+    this->winInfo->initialize(parentWindowId, 15, 150);
+  }
+  
+} // namespace minsky

--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -79,34 +79,12 @@ namespace minsky
   }
 #endif
 
-  RenderNativeWindow::~RenderNativeWindow()
+  void RenderNativeWindow::renderFrame(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight)
   {
-    if (this->winInfo)
-    {
-      delete this->winInfo;
-    }
-  }
+    if (!winInfoPtr)
+     winInfoPtr=std::make_shared<WindowInformation>(parentWindowId, offsetLeft, offsetTop, childWidth, childHeight);
 
-  RenderNativeWindow::RenderNativeWindow()
-  {
-    this->winInfo = new WindowInformation();
-  }
-
-  RenderNativeWindow &RenderNativeWindow::operator=(const RenderNativeWindow &a)
-  {
-    //TODO:: I expected this to be the "new" instance with uninitialized winInfo and a to have the previous winInfo.
-    // However, it seems to be the other way round in practice --- Janak
-    a.winInfo->initialize(*(this->winInfo));
-  }
-
-  RenderNativeWindow::RenderNativeWindow(const RenderNativeWindow &a)
-  {
-    // cout << "Copy constructor was called" << endl;
-  }
-
-  void RenderNativeWindow::renderFrame()
-  {
-    auto tmp = createNativeWindowSurface(*winInfo);
+    auto tmp = createNativeWindowSurface(*winInfoPtr);
 
     //TODO:: Review if this paint (below 3 lines) is really needed with each frame
     cairo_move_to(tmp->cairo(), 0, 0);
@@ -116,12 +94,6 @@ namespace minsky
     tmp.swap(surface);
     redraw(0, 0, surface->width(), surface->height());
     tmp.swap(surface);
-  }
-
-  void RenderNativeWindow::initializeNativeWindow(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight) {
-    //std::cout << parentWindowId << "::" << offsetLeft << "::" << offsetTop << "::" << childWidth << "::" << childHeight << std::endl;
-    winInfo->initialize(parentWindowId, offsetLeft, offsetTop, childWidth, childHeight);
-    //std::cout << "Child window id:: " << winInfo->getChildWindowId() << std::endl;
   }
 
   void RenderNativeWindow::resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight)

--- a/model/renderNativeWindow.cc
+++ b/model/renderNativeWindow.cc
@@ -103,7 +103,7 @@ namespace minsky
     childWidth = wAttr.width - 2 * padding;
     childHeight = wAttr.height - yOffset - padding;
 
-    childWindowId = XCreateSimpleWindow(display, parentWin, offsetTop, offsetLeft, childWidth, childHeight, 0, 0, 0);
+    childWindowId = XCreateSimpleWindow(display, parentWin, offsetLeft, offsetTop, childWidth, childHeight, 0, 0, 0); //TODO:: Should we pass visual and attributes at the end?
     XMapWindow(display, childWindowId);
   }
 

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -29,20 +29,11 @@ namespace minsky
   {
   private:
     CLASSDESC_ACCESS(RenderNativeWindow); 
-    // std::shared_ptr<WindowInformation> winInfoPtr; // TODO:: cannot get things to work with this
-    WindowInformation* winInfo;
+    std::shared_ptr<WindowInformation> winInfoPtr;
 
-  public:
-
-    RenderNativeWindow();
-    ~RenderNativeWindow();
-    RenderNativeWindow& operator=(const RenderNativeWindow &a);
-    RenderNativeWindow(const RenderNativeWindow &a);
-
-
-    void initializeNativeWindow(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight);
+  public:    
     void resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight);
-    void renderFrame();
+    void renderFrame(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight);
   };
 } // namespace minsky
 

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -38,7 +38,7 @@ namespace minsky
 
     WindowInformation();
     ~WindowInformation();
-    void initialize(unsigned long parentWin, int offsetLeft, int offsetTop);
+    void initialize(unsigned long parentWin, int offsetLeft, int offsetTop, int childWidth, int childHeight);
     void copy(WindowInformation *winInfo);
   };
 
@@ -54,7 +54,10 @@ namespace minsky
     RenderNativeWindow(const RenderNativeWindow &a);
 
   public:
-    void initializeNativeWindow(unsigned long parentWindowId);
+    void initializeNativeWindow(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight);
+    
+    void resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight);
+
     void renderFrame();
   };
 } // namespace minsky

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -44,7 +44,8 @@ namespace minsky
 
   class RenderNativeWindow : public ecolab::CairoSurface
   {
-  private:
+  public:
+    /* Perhaps needs to be public for some auto-binding code */
     WindowInformation *winInfo;
 
   public:

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -23,42 +23,25 @@
 #include <cairoSurfaceImage.h>
 
 namespace minsky
-{
-  struct WindowInformation
-  {
-    unsigned long parentWindowId;
-    unsigned long childWindowId;
-    int childWidth;
-    int childHeight;
-    int offsetLeft;
-    int offsetTop;
-    Display*	display;
-    XWindowAttributes wAttr;
-    ecolab::cairo::SurfacePtr *childSurface; // TODO:: Review right way to store surface ptr
-
-    WindowInformation();
-    ~WindowInformation();
-    void initialize(unsigned long parentWin, int offsetLeft, int offsetTop, int childWidth, int childHeight);
-    void copy(WindowInformation *winInfo);
-  };
-
+{  
+  class WindowInformation;
   class RenderNativeWindow : public ecolab::CairoSurface
   {
-  public:
-    /* Perhaps needs to be public for some auto-binding code */
-    WindowInformation *winInfo;
+  private:
+    CLASSDESC_ACCESS(RenderNativeWindow); 
+    // std::shared_ptr<WindowInformation> winInfoPtr; // TODO:: cannot get things to work with this
+    WindowInformation* winInfo;
 
   public:
+
     RenderNativeWindow();
     ~RenderNativeWindow();
     RenderNativeWindow& operator=(const RenderNativeWindow &a);
     RenderNativeWindow(const RenderNativeWindow &a);
 
-  public:
-    void initializeNativeWindow(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight);
-    
-    void resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight);
 
+    void initializeNativeWindow(unsigned long parentWindowId, int offsetLeft, int offsetTop, int childWidth, int childHeight);
+    void resizeWindow(int offsetLeft, int offsetTop, int childWidth, int childHeight);
     void renderFrame();
   };
 } // namespace minsky

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -27,6 +27,9 @@ namespace minsky
   class RenderNativeWindow: public ecolab::CairoSurface
   {
   public:
+    void initializeNativeWindow(unsigned long window);
+    void renderFrame();
+
     void renderToNativeWindow(unsigned long window);
   };
 }

--- a/model/renderNativeWindow.h
+++ b/model/renderNativeWindow.h
@@ -24,15 +24,40 @@
 
 namespace minsky
 {
-  class RenderNativeWindow: public ecolab::CairoSurface
+  struct WindowInformation
   {
-  public:
-    void initializeNativeWindow(unsigned long window);
-    void renderFrame();
+    unsigned long parentWindowId;
+    unsigned long childWindowId;
+    int childWidth;
+    int childHeight;
+    int offsetLeft;
+    int offsetTop;
+    Display*	display;
+    XWindowAttributes wAttr;
+    ecolab::cairo::SurfacePtr *childSurface; // TODO:: Review right way to store surface ptr
 
-    void renderToNativeWindow(unsigned long window);
+    WindowInformation();
+    ~WindowInformation();
+    void initialize(unsigned long parentWin, int offsetLeft, int offsetTop);
+    void copy(WindowInformation *winInfo);
   };
-}
+
+  class RenderNativeWindow : public ecolab::CairoSurface
+  {
+  private:
+    WindowInformation *winInfo;
+
+  public:
+    RenderNativeWindow();
+    ~RenderNativeWindow();
+    RenderNativeWindow& operator=(const RenderNativeWindow &a);
+    RenderNativeWindow(const RenderNativeWindow &a);
+
+  public:
+    void initializeNativeWindow(unsigned long parentWindowId);
+    void renderFrame();
+  };
+} // namespace minsky
 
 #include "renderNativeWindow.cd"
 #endif

--- a/model/windowInformation.cc
+++ b/model/windowInformation.cc
@@ -38,11 +38,6 @@ namespace minsky
     throw runtime_error(errorMessage);
   }
 #endif
-
-  WindowInformation::WindowInformation()
-  {
-  }
-
   unsigned long WindowInformation::getChildWindowId()
   {
     return childWindowId;
@@ -59,12 +54,12 @@ namespace minsky
     XDestroyWindow(display, childWindowId);
   }
 
-  void WindowInformation::initialize(const WindowInformation &other)
+  ecolab::cairo::SurfacePtr WindowInformation::getSurface()
   {
-    this->initialize(other.parentWindowId, other.offsetLeft, other.offsetTop, other.childWidth, other.childHeight);
+    return childSurface;
   }
 
-  void WindowInformation::initialize(unsigned long parentWin, int left, int top, int cWidth, int cHeight)
+  WindowInformation::WindowInformation(unsigned long parentWin, int left, int top, int cWidth, int cHeight)
   {
     parentWindowId = parentWin;
     offsetLeft = left;
@@ -96,15 +91,4 @@ namespace minsky
     XMapWindow(display, childWindowId);
     // std::cout << "We got child window id = " << childWindowId << std::endl;
   }
-
-  ecolab::cairo::SurfacePtr WindowInformation::getSurface()
-  {
-    return childSurface;
-  }
-
-  WindowInformation::WindowInformation(unsigned long parentWin, int left, int top, int cWidth, int cHeight)
-  {
-    this->initialize(parentWin, left, top, cWidth, cHeight);
-  }
-
 } // namespace minsky

--- a/model/windowInformation.cc
+++ b/model/windowInformation.cc
@@ -1,0 +1,110 @@
+/*
+  @copyright Steve Keen 2021
+  @author Janak Porwal
+  This file is part of Minsky.
+
+  Minsky is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Minsky is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Minsky.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "windowInformation.h"
+#include "minsky_epilogue.h"
+
+#include <stdexcept>
+#include <string>
+
+using namespace std;
+using namespace ecolab;
+
+namespace minsky
+{
+#ifdef USE_WIN32_SURFACE
+#elif defined(MAC_OSX_TK)
+#else
+  int throwOnXError(Display *, XErrorEvent *ev)
+  {
+    char errorMessage[256];
+    XGetErrorText(ev->display, ev->error_code, errorMessage, sizeof(errorMessage));
+    throw runtime_error(errorMessage);
+  }
+#endif
+
+  WindowInformation::WindowInformation()
+  {
+  }
+
+  unsigned long WindowInformation::getChildWindowId()
+  {
+    return childWindowId;
+  }
+
+  Display *WindowInformation::getDisplay()
+  {
+    return display;
+  }
+
+  WindowInformation::~WindowInformation()
+  {
+    childSurface.reset();
+    XDestroyWindow(display, childWindowId);
+  }
+
+  void WindowInformation::initialize(const WindowInformation &other)
+  {
+    this->initialize(other.parentWindowId, other.offsetLeft, other.offsetTop, other.childWidth, other.childHeight);
+  }
+
+  void WindowInformation::initialize(unsigned long parentWin, int left, int top, int cWidth, int cHeight)
+  {
+    parentWindowId = parentWin;
+    offsetLeft = left;
+    offsetTop = top;
+
+    static bool errorHandlingSet = (XSetErrorHandler(throwOnXError), true);
+    display = XOpenDisplay(nullptr);
+    int err = XGetWindowAttributes(display, parentWin, &wAttr);
+    if (err > 1)
+      throw runtime_error("Invalid window: " + to_string(parentWin));
+
+    childWidth = wAttr.width - offsetLeft;
+    childHeight = wAttr.height - offsetTop;
+
+    // Todo:: currently width, height parameters are not getting passed properly
+    // Eventually, we need those in order to ensure we don't need to worry about
+    // paddings, scrollbars etc
+    if (cWidth > 0)
+    {
+      childWidth = min(childWidth, cWidth);
+    }
+    if (cHeight > 0)
+    {
+      childHeight = min(childHeight, cHeight);
+    }
+
+    // std::cout << childWidth << "::" << childHeight << "::" << offsetLeft << "::" << offsetTop << std::endl;
+    childWindowId = XCreateSimpleWindow(display, parentWin, offsetLeft, offsetTop, childWidth, childHeight, 0, 0, 0); //TODO:: Should we pass visual and attributes at the end?
+    XMapWindow(display, childWindowId);
+    // std::cout << "We got child window id = " << childWindowId << std::endl;
+  }
+
+  ecolab::cairo::SurfacePtr WindowInformation::getSurface()
+  {
+    return childSurface;
+  }
+
+  WindowInformation::WindowInformation(unsigned long parentWin, int left, int top, int cWidth, int cHeight)
+  {
+    this->initialize(parentWin, left, top, cWidth, cHeight);
+  }
+
+} // namespace minsky

--- a/model/windowInformation.h
+++ b/model/windowInformation.h
@@ -44,17 +44,11 @@ namespace minsky
       Display* getDisplay();
 
   public:
-
-    
-    WindowInformation();
     ~WindowInformation();
     WindowInformation(unsigned long parentWin, int left, int top, int cWidth, int cHeight);
-    void initialize(unsigned long parentWin, int left, int top, int cWidth, int cHeight);
-    void initialize(const WindowInformation &other);
-
+    
     ecolab::cairo::SurfacePtr getSurface();
 
-    void copyFrom(const WindowInformation &other);
     WindowInformation(const WindowInformation&)=delete;
     void operator=(const WindowInformation&)=delete;
   };

--- a/model/windowInformation.h
+++ b/model/windowInformation.h
@@ -33,6 +33,8 @@ namespace minsky
     Display*	display; // Weak reference, returned by system
     ecolab::cairo::SurfacePtr childSurface;
 
+  private:
+      void createSurface();
   public: 
       int childWidth;
       int childHeight;

--- a/model/windowInformation.h
+++ b/model/windowInformation.h
@@ -1,0 +1,63 @@
+/*
+  @copyright Steve Keen 2021
+  @author Janak Porwal
+  This file is part of Minsky.
+
+  Minsky is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Minsky is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Minsky.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef WINDOW_INFORMATION_H
+#define WINDOW_INFORMATION_H
+
+#include <cairoSurfaceImage.h>
+#include <X11/Xlib.h>
+
+namespace minsky
+{
+  class WindowInformation
+  {
+    unsigned long parentWindowId;
+    unsigned long childWindowId;
+    
+    Display*	display; // Weak reference, returned by system
+    ecolab::cairo::SurfacePtr childSurface;
+
+  public: 
+      int childWidth;
+      int childHeight;
+      int offsetLeft;
+      int offsetTop;
+      
+      XWindowAttributes wAttr;
+      unsigned long getChildWindowId();
+      Display* getDisplay();
+
+  public:
+
+    
+    WindowInformation();
+    ~WindowInformation();
+    WindowInformation(unsigned long parentWin, int left, int top, int cWidth, int cHeight);
+    void initialize(unsigned long parentWin, int left, int top, int cWidth, int cHeight);
+    void initialize(const WindowInformation &other);
+
+    ecolab::cairo::SurfacePtr getSurface();
+
+    void copyFrom(const WindowInformation &other);
+    WindowInformation(const WindowInformation&)=delete;
+    void operator=(const WindowInformation&)=delete;
+  };
+} // namespace minsky
+
+#endif


### PR DESCRIPTION
We have created a struct `WindowInformation` that stores the `childWindowId` along with other details like display and window attributes. This information is reused across multiple calls to `renderFrame`. 

The flow for code will be -- when minsky starts:
A call to` /minsky/canvas/initializeNativeWindow ` will be made, with parentWindowId (and offsets) as the parameters (creating child window in electron did not work as expected, so we need to work with offsets). 
Subsequent repaints can be requested with ` /minsky/canvas/renderFrame`

As of now, we create a cairo surface with each call to `renderFrame`, though I think the surface can also be reused. I tried having pointer to cairo::SurfacePtr (not sure we should have pointer to pointer) but it didn't work as expected (maybe syntax related usage issue), so for now I reverted to recreating the surface in the call to `renderFrame`


Please especially review the lifecycle (constructors, desctructors and copy constructors) that I have defined in `renderNativeWindow.cc `. I think the `WindowInformation` object that is destroyed in the destructor for `RenderNativeWindow` can also be reused (perhaps it can be made a static object?). 

Also - am not sure how to distinguish between destructor for `RenderNativeWindow` that will be called with each call to load model (or undo/redo as you mentioned), and the final call when minsky is closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/285)
<!-- Reviewable:end -->
