### PR TITLE
Godleys and plots on tabs now update while model is running. Display …

### DIFF
--- a/gui-tk/minsky.tcl
+++ b/gui-tk/minsky.tcl
@@ -962,9 +962,6 @@ bind .gdlys.canvas <ButtonRelease-1> {wrapHoverMouseTab godleyTab mouseUp %x %y}
 bind .gdlys.canvas <Motion> {.plts.canvas configure -cursor {}; wrapHoverMouseTab godleyTab mouseMove %x %y}
 bind .gdlys.canvas <Leave> {after cancel hoverMouseTab godleyTab}
 
-bind .gdlys.canvas <<contextMenu>> "tabContext %x %y %X %Y"  
-menu .gdlys.context -tearoff 0  
-
 .tabs select 0
 
 proc hoverMouseTab {tabId} {
@@ -999,13 +996,6 @@ proc tabContext {x y X Y} {
 				.plts.context add command -label "Remove plot from tab" -command "plotTab.togglePlotDisplay;  plotTab.requestRedraw"
 			}
             tk_popup .plts.context $X $Y
-		}
-	    .gdlys {
-			.gdlys.context delete 0 end
-			if [getGodleyTabItemAt $x $y] {
-				.gdlys.context add command -label "Toggle value display" -command "godleyTab.toggleGodleyTabValueDisplay; godleyTab.requestRedraw"
-			}
-            tk_popup .gdlys.context $X $Y
 		}		
 	}
 }

--- a/model/godleyIcon.h
+++ b/model/godleyIcon.h
@@ -79,11 +79,7 @@ namespace minsky
     /// sets editor's display values attributes to current global preferences
     void setEditorDisplayValues();
     
-    CopiableUniquePtr godleyT;
-    
-    bool godleyTabValueDisplay=true;
-    void toggleGodleyTabValueDisplay() {godleyTabValueDisplay=!godleyTabValueDisplay;} 
-    bool tabDisplayValues() const {return godleyTabValueDisplay;}            
+    CopiableUniquePtr godleyT;    
 
     /// scale icon until it's height or width matches \a h or \a w depending on which is minimum             
     void scaleIcon(float w, float h);         

--- a/model/godleyTab.cc
+++ b/model/godleyTab.cc
@@ -35,11 +35,6 @@ namespace minsky
     return dynamic_cast<GodleyIcon*>(i.get());
   }
   
-  void GodleyTab::toggleGodleyTabValueDisplay() const      
-  {
-    if (auto g=dynamic_cast<GodleyIcon*>(item.get())) g->toggleGodleyTabValueDisplay();
-  }	  	
-  
   ItemPtr GodleyTab::itemAt(float x, float y)
   {
     ItemPtr item;                    
@@ -93,7 +88,7 @@ namespace minsky
               itemCoords[itemFocus]=move(make_pair(xItem,yItem));         
             } else cairo_translate(cairo,itemCoords[it].first,itemCoords[it].second);
             g->godleyT->disableButtons();
-            g->godleyT->displayValues=g->tabDisplayValues();   
+            g->godleyT->displayValues=minsky().displayValues;
             g->godleyT->draw(cairo);
             
             // draw title

--- a/model/godleyTab.h
+++ b/model/godleyTab.h
@@ -29,7 +29,6 @@ namespace minsky
   {	  
   public:
     bool itemSelector(const ItemPtr& i) override;
-    void toggleGodleyTabValueDisplay() const;
     ItemPtr itemAt(float x, float y) override;
     void draw(cairo_t* cairo) override;
   };

--- a/model/minsky.cc
+++ b/model/minsky.cc
@@ -932,6 +932,10 @@ namespace minsky
     running=false;
 
     canvas.requestRedraw();
+    godleyTab.requestRedraw();
+    plotTab.requestRedraw();
+    variableTab.requestRedraw();
+    parameterTab.requestRedraw();    
   }
 
   void Minsky::step()
@@ -1032,6 +1036,10 @@ namespace minsky
     if ((microsec_clock::local_time()-(ptime&)lastRedraw) > maxWait)
       {
         canvas.requestRedraw();
+        godleyTab.requestRedraw();
+        plotTab.requestRedraw();
+        variableTab.requestRedraw();
+        parameterTab.requestRedraw();        
         lastRedraw=microsec_clock::local_time();
       }
 


### PR DESCRIPTION
…values on Godley tab the same as global preferences. Sorry, I'd have wanted to do this sooner and also fix other tickets I've committed to, but I need to urgently fix a serious bug in ANT.Gaussian (related to integration in the complex plane) which my postdoc research depends crucially on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/286)
<!-- Reviewable:end -->
