### PR TITLE
Enable range checks for arrays, vectors and strings in debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ FLAGS+=-std=c++14 -Ischema -Iengine -Imodel -Icertify/include -IRESTService -IRa
 # NB see #1486 - we need to update the use of rsvg, then we can remove -Wno-deprecated-declarations
 #-fvisibility-inlines-hidden
 
+ifeq ($(DEBUG), 1)
+FLAGS+=-Wp,-D_GLIBCXX_ASSERTIONS
+endif
+
 VPATH= schema model engine gui-tk RESTService RavelCAPI/civita RavelCAPI $(ECOLAB_HOME)/include 
 
 .h.xcd:


### PR DESCRIPTION
`-Wp,-D_GLIBCXX_ASSERTIONS` is the flag that has been causing the problems in Fedora. With the recent changes that have been merged and in my cursory testing I have not come across any crash. I suggest this flag is enabled in upstream itself (here) to protect against this class of bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/370)
<!-- Reviewable:end -->
