### PR TITLE
Bundle desktop file and icon in JS distribution file

### DIFF
--- a/makeJsDist.sh
+++ b/makeJsDist.sh
@@ -9,6 +9,12 @@ fi
 pushd gui-js
 npm run export:package:linux
 pushd dist/executables/
-mv linux-unpacked $name
-rm $name/resources/node-addons/*.node
+mkdir $name
+mv linux-unpacked $name/app
+rm $name/app/resources/node-addons/*.node
+popd
+popd
+cp minsky.desktop gui-js/dist/executables/$name/
+cp gui-tk/icons/MinskyLogo.svg gui-js/dist/executables/$name/minsky.svg
+pushd gui-js/dist/executables/
 tar zcvf /tmp/$name.tar.gz $name

--- a/minsky.desktop
+++ b/minsky.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Minsky
+Exec=minsky %U
+Terminal=false
+Type=Application
+Icon=minsky
+StartupWMClass=minsky
+Comment=Graphical dynamical systems simulator oriented towards economics
+Categories=Science;


### PR DESCRIPTION
This needs adaptation in the files for deb and rpm packages in OBS. The root of the electron app is now under `app/` and the desktop file has to be copied to `/usr/share/applications` and the icon file to `/usr/share/icons/hicolor/scalable/apps`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/373)
<!-- Reviewable:end -->
