### PR TITLE
Fixed up handling of .rvl files when Ravel is not present. initState …

### DIFF
--- a/model/plotWidget.cc
+++ b/model/plotWidget.cc
@@ -249,7 +249,7 @@ namespace minsky
       // label pens
       for (size_t i=0; i<yvars.size(); ++i)
         if (yvars[i] && !yvars[i]->name.empty())
-          labelPen(i, latexToPango(yvars[i]->name));
+          labelPen(i, latexToPango(uqName(yvars[i]->name)));
   }
 
   void PlotWidget::mouseDown(float x,float y)

--- a/model/ravelWrap.cc
+++ b/model/ravelWrap.cc
@@ -191,6 +191,7 @@ namespace minsky
   
   void Ravel::populateHypercube(const Hypercube& hc)
   {
+    if (!wrappedRavel) return;
     auto state=initState.empty()? getState(): initState;
     bool redistribute=!initState.empty();
     initState.clear();
@@ -498,6 +499,10 @@ namespace minsky
 
   void Ravel::applyState(const ravel::RavelState& state)
  {
+   if (!wrappedRavel) {
+     initState=state;
+     return;
+   }
    auto r=wrappedRavel.radius();
    wrappedRavel.setRavelState(state);
    if (state.radius!=r) // only need to update bounding box if radius changes

--- a/model/ravelWrap.h
+++ b/model/ravelWrap.h
@@ -195,7 +195,7 @@ namespace minsky
     /// @}
     
     /// get the current state of the Ravel
-    ravel::RavelState getState() const {return wrappedRavel.getRavelState();}
+    ravel::RavelState getState() const {return wrappedRavel? wrappedRavel.getRavelState(): initState;}
     /// apply the \a state to the Ravel, leaving data, slicelabels etc unchanged
     /// @param preservePositions if true, do not rotate handles
     void applyState(const ravel::RavelState& state);


### PR DESCRIPTION
…stashes the saved state, and applyState/getState now handles situation where ravel not present. For #1696.

Fix effect of recent change to variableValue name attribute on plot legends.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/429)
<!-- Reviewable:end -->
