### PR TITLE
fixed deleteKey test

### DIFF
--- a/test/00/deleteKey.sh
+++ b/test/00/deleteKey.sh
@@ -82,7 +82,7 @@ def deleteKey(x, y):
         print(f"No item found at ({x}, {y}).")
 
 # Step 1: Delete the wire at coordinates (415, 290)
-deleteKey(450, 50)
+deleteKey(415, 290)
 assert minsky.model.numWires() == (numWires - 1), "Test wire deletion failed."
 
 # Step 2: Delete the variable 'emprate'

--- a/test/00/deleteKey.sh
+++ b/test/00/deleteKey.sh
@@ -81,8 +81,8 @@ def deleteKey(x, y):
     else:
         print(f"No item found at ({x}, {y}).")
 
-# Step 1: Delete the wire at coordinates (415, 290)
-deleteKey(415, 290)
+# Step 1: Delete the wire at coordinates (450, 50)
+deleteKey(450, 50)
 assert minsky.model.numWires() == (numWires - 1), "Test wire deletion failed."
 
 # Step 2: Delete the variable 'emprate'


### PR DESCRIPTION
DeleteKey test fails at the original coordinates of (450, 50) and passes at (415,290). This is because more than one wire and object are deleted at (450,50). So I either have to modify all the assertion numbers or the coordinates so that the test works. I prefer to delete a single wire at another position than have multiple wires and /or objects be deleted at the original set of coordinates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/528)
<!-- Reviewable:end -->
