### PR TITLE
Pythonised inputWire test

### DIFF
--- a/test/00/inputWired.sh
+++ b/test/00/inputWired.sh
@@ -27,15 +27,38 @@ pass()
 }
 
 trap "fail" 1 2 3 15
-cat >input.tcl <<EOF
-source $here/test/assert.tcl
-minsky.addOperation integrate
-minsky.findObject Variable:integral
-assert {[minsky.inputWired [minsky.canvas.item.valueId]]}
-tcl_exit
+cat >input.py <<EOF
+import sys
+sys.path.insert(0, '$here')
+from pyminsky import minsky, findObject
+
+# Add an integration operation to the canvas
+minsky.canvas.addOperation("integrate")
+
+# Use findObject to locate the integration operation (IntOp)
+integrationOp = findObject("IntOp")
+assert integrationOp is not None, "Integration operation not found or not focused"
+
+# Use findObject to locate the integral variable (Variable:integral)
+integralVariable = findObject("Variable:integral")
+assert integralVariable is not None, "Integral variable not found or not focused"
+
+# Match the integral variable's position with items in the model to retrieve valueId
+value_id = None
+for i in range(len(minsky.model.items)):
+    item = minsky.model.items[i]
+    if item.x() == integralVariable.x() and item.y() == integralVariable.y():
+        value_id = item.valueId()
+        break
+
+# Ensure the value_id is valid
+assert value_id is not None, "Integral variable does not have a valueId"
+
+# Verify that the integral variable input is wired
+assert minsky.inputWired(value_id), "Integral variable input is not wired"
 EOF
 
-$here/gui-tk/minsky input.tcl
+python3 input.py
 if [ $? -ne 0 ]; then fail; fi
 
 pass


### PR DESCRIPTION
Thought this one would be more straightforward, but it seems that the C++-wrapped findObject method does not expose more attributes to the pyminsky module than those in the item class, and, as a result, one can't access subattributes of specific item types directly from the object returned by findObject, e.g., name, valueId, etc. Thus, I have resorted to iterating minsky.model.items to expose the attribute required for the test (valueId).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/531)
<!-- Reviewable:end -->
