### PR TITLE
Added logic to ensure mousefocus is set only only one item at a time.…

### DIFF
--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -298,6 +298,7 @@ namespace minsky
               requestRedraw();
             };
             // set mouse focus to display ports etc.
+            bool mouseFocusSet=false; // ensure only one item is focused by mouse.
             model->recursiveDo(&Group::items, [&](Items&,Items::iterator& i)
                                               {
                                                 (*i)->disableDelayedTooltip();
@@ -311,7 +312,8 @@ namespace minsky
                                                 else
                                                   {
                                                     auto ct=(*i)->clickType(x,y);
-                                                    setFlagAndRequestRedraw((*i)->mouseFocus, ct!=ClickType::outside);
+                                                    setFlagAndRequestRedraw((*i)->mouseFocus, !mouseFocusSet && ct!=ClickType::outside);
+                                                    if ((*i)->mouseFocus) mouseFocusSet=true;
                                                     setFlagAndRequestRedraw((*i)->onResizeHandles, ct==ClickType::onResize);
                                                     setFlagAndRequestRedraw((*i)->onBorder, ct==ClickType::onItem);
                                                     if (ct==ClickType::outside)
@@ -324,7 +326,8 @@ namespace minsky
             model->recursiveDo(&Group::groups, [&](Groups&,Groups::iterator& i)
                                                {
                                                  auto ct=(*i)->clickType(x,y);
-                                                 const bool mf=ct!=ClickType::outside;
+                                                 const bool mf=!mouseFocusSet && ct!=ClickType::outside;
+                                                 if (mf) mouseFocusSet=true;
                                                  if (mf!=(*i)->mouseFocus)
                                                    {
                                                      (*i)->mouseFocus=mf;

--- a/model/canvas.cc
+++ b/model/canvas.cc
@@ -326,13 +326,8 @@ namespace minsky
             model->recursiveDo(&Group::groups, [&](Groups&,Groups::iterator& i)
                                                {
                                                  auto ct=(*i)->clickType(x,y);
-                                                 const bool mf=!mouseFocusSet && ct!=ClickType::outside;
-                                                 if (mf) mouseFocusSet=true;
-                                                 if (mf!=(*i)->mouseFocus)
-                                                   {
-                                                     (*i)->mouseFocus=mf;
-                                                     requestRedraw();
-                                                   }
+                                                 setFlagAndRequestRedraw((*i)->mouseFocus, !mouseFocusSet && ct!=ClickType::outside);
+                                                 if ((*i)->mouseFocus) mouseFocusSet=true;
                                                  const bool onResize = ct==ClickType::onResize;
                                                  if (onResize!=(*i)->onResizeHandles)
                                                    {


### PR DESCRIPTION
… For ravel #671.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/542)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined mouse interaction behavior to ensure only one element is highlighted at a time, reducing unintended multi-selection. This change provides a smoother and more predictable experience when selecting items, groups, and similar elements, enhancing overall user control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->