### PR TITLE
Add sparse-data unit test for xvector-based linear regression

### DIFF
--- a/engine/minskyTensorOps.cc
+++ b/engine/minskyTensorOps.cc
@@ -1160,7 +1160,6 @@ namespace minsky
             dimension=i-xv.begin();
       }
       
-      sumy.setArgument(y,args);
       TensorPtr spreadX;
       if (x)
         {
@@ -1195,10 +1194,12 @@ namespace minsky
             }
         }
       auto mask=[](double x, double y){return isfinite(x) && isfinite(y);};
-      auto fx=[](double x, double y){return isfinite(x) && isfinite(y)? x:0;};
-      auto fxy=[](double x, double y){return isfinite(x) && isfinite(y)? x*y: 0;};
+      auto fx=[mask](double x, double y){return mask(x,y)? x:0;};
+      auto fxy=[mask](double x, double y){return mask(x,y)? x*y: 0;};
       auto maskedX=make_shared<BinOp>(fx,spreadX,y);
+      auto maskedY=make_shared<BinOp>(fx,y,spreadX);
       sumx.setArgument(maskedX,args);
+      sumy.setArgument(maskedY,args);
       sumyy.setArgument(make_shared<BinOp>(fxy,y,y),args);
       sumxx.setArgument(make_shared<BinOp>(fxy,maskedX,spreadX),args);
       sumxy.setArgument(make_shared<BinOp>(fxy,y,spreadX),args);

--- a/engine/minskyTensorOps.cc
+++ b/engine/minskyTensorOps.cc
@@ -1200,7 +1200,7 @@ namespace minsky
       auto maskedY=make_shared<BinOp>(fx,y,spreadX);
       sumx.setArgument(maskedX,args);
       sumy.setArgument(maskedY,args);
-      sumyy.setArgument(make_shared<BinOp>(fxy,y,y),args);
+      sumyy.setArgument(make_shared<BinOp>(fxy,maskedY,y),args);
       sumxx.setArgument(make_shared<BinOp>(fxy,maskedX,spreadX),args);
       sumxy.setArgument(make_shared<BinOp>(fxy,y,spreadX),args);
       count.setArgument(make_shared<BinOp>(mask,y,spreadX),args);

--- a/engine/minskyTensorOps.cc
+++ b/engine/minskyTensorOps.cc
@@ -1169,7 +1169,7 @@ namespace minsky
         }
       else
         {
-          if (rank()>1 && dimension>=y->rank()) return;
+          if (y->rank()>1 && dimension>=y->rank()) return;
           // construct x from y's x-vector
           auto tv=make_shared<TensorVal>();
           spreadX=tv;
@@ -1194,13 +1194,15 @@ namespace minsky
                 }
             }
         }
-      sumx.setArgument(spreadX,args);
+      auto mask=[](double x, double y){return isfinite(x) && isfinite(y);};
+      auto fx=[](double x, double y){return isfinite(x) && isfinite(y)? x:0;};
       auto fxy=[](double x, double y){return isfinite(x) && isfinite(y)? x*y: 0;};
+      auto maskedX=make_shared<BinOp>(fx,spreadX,y);
+      sumx.setArgument(maskedX,args);
       sumyy.setArgument(make_shared<BinOp>(fxy,y,y),args);
-      sumxx.setArgument(make_shared<BinOp>(fxy,spreadX,spreadX),args);
+      sumxx.setArgument(make_shared<BinOp>(fxy,maskedX,spreadX),args);
       sumxy.setArgument(make_shared<BinOp>(fxy,y,spreadX),args);
-      count.setArgument
-        (make_shared<BinOp>([](double x,double y) {return isfinite(x)*isfinite(y);},y,spreadX),args);
+      count.setArgument(make_shared<BinOp>(mask,y,spreadX),args);
       
       assert(sumx.hypercube()==sumy.hypercube());
       assert(sumx.index()==sumy.index());

--- a/test/testTensorOps.cc
+++ b/test/testTensorOps.cc
@@ -1844,6 +1844,28 @@ TEST_F(CorrelationSuite,xvectorValueLinearRegression)
   for (size_t _i=0; _i<toVal.size(); ++_i) EXPECT_NEAR(result[_i], toVal[_i], 1e-4);
 }
 
+TEST_F(CorrelationSuite,xvectorValueLinearRegressionSparse)
+{
+  // y = x + 1, but with NaN/Inf interspersed. Regression should use only finite (x,y) pairs.
+  Hypercube hc;
+  hc.xvectors.emplace_back("0", Dimension(Dimension::value,""), vector<civita::any>{0,1,2,3,4,5});
+  TensorVal y(hc); y=vector<double>{1, std::numeric_limits<double>::quiet_NaN(), 3, 4,
+                                    std::numeric_limits<double>::infinity(), 6};
+  fromVal=y;
+
+  // finite pairs: (x=0,y=1),(x=2,y=3),(x=3,y=4),(x=5,y=6) => line y=x+1
+  vector<double> result={1,2,3,4,5,6};
+
+  OperationPtr op(OperationType::linearRegression);
+  g->addItem(op);
+  Wire w1(from->ports(0),op->ports(1)), w3(op->ports(0),to->ports(1));
+  Eval(*to, op)();
+
+  auto& toVal=*to->vValue();
+  EXPECT_EQ(result.size(), toVal.size());
+  for (size_t _i=0; _i<toVal.size(); ++_i) EXPECT_NEAR(result[_i], toVal[_i], 1e-4);
+}
+
 TEST_F(CorrelationSuite,xvectorTimeLinearRegression)
 {
   Hypercube hc;

--- a/test/testTensorOps.cc
+++ b/test/testTensorOps.cc
@@ -1862,7 +1862,7 @@ TEST_F(CorrelationSuite,xvectorValueLinearRegressionSparse)
   Eval(*to, op)();
 
   auto& toVal=*to->vValue();
-  EXPECT_EQ(result.size(), toVal.size());
+  ASSERT_EQ(result.size(), toVal.size());
   for (size_t _i=0; _i<toVal.size(); ++_i) EXPECT_NEAR(result[_i], toVal[_i], 1e-4);
 }
 


### PR DESCRIPTION
Linear regression using a y tensor's x-vector for x-values was silently producing incorrect results when y contained non-finite entries (`NaN`/`Inf`), because `sumx` and `sumxx` were not masked to finite pairs.

## Changes

- **Test coverage** (`test/testTensorOps.cc`): Adds `xvectorValueLinearRegressionSparse` — a gtest case with `y = {1, NaN, 3, 4, Inf, 6}` over x-vector `{0,1,2,3,4,5}`. Verifies that only the four finite pairs are used and the regression recovers `y = x + 1` across all output slots.

```cpp
TensorVal y(hc); y=vector<double>{1, std::numeric_limits<double>::quiet_NaN(), 3, 4,
                                  std::numeric_limits<double>::infinity(), 6};
// finite pairs: (0,1),(2,3),(3,4),(5,6) => slope=1, intercept=1
vector<double> result={1,2,3,4,5,6};
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/highperformancecoder/minsky/643)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linear regression now properly excludes non-finite values (NaN and Inf) from calculations, ensuring accurate regression results when working with sparse or incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->